### PR TITLE
Expedition Economy — Core Loop (Plan 1 of 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,12 @@ Active features (registered in `src/bot/index.ts`): start, help, queue (admin), 
 - `addPoints()` uses `$inc` + logs to Balance model
 - Daily claim: 60s cooldown, 10-day streak, 100 base × multiplier
 - CNFT type at mint time (`pickCNFTType` in `src/common/models/CNFT.ts`): Whale (>1M votes), Diamond (>500K), Coin (>100K), Knight (>0 referrals), Common. `Dice` is a legacy type still in the enum and on past records but no longer produced — the `/dice` command was removed and `diceWinner` is never set to true for new users.
-- `BalanceChangeType` enum (`src/common/models/Balance.ts`): Initial, Deposit, Withdraw, Dice, Referral, Donation, Task, Claim, Trade. `Dice` and `Task` are legacy values; new entries are Claim/Referral/Donation/Trade.
+- `BalanceChangeType` enum (`src/common/models/Balance.ts`): Initial, Deposit, Withdraw, Dice, Referral, Donation, Task, Claim, Trade, Expedition, Spend. `Dice` and `Task` are legacy values; new entries are Claim/Referral/Donation/Trade. `Expedition` is the expedition-loop CUBE faucet (settlement payout); `Spend` is its CUBE sink (energy refill / weight-boost).
+- Expedition economy core loop (`#root/common/helpers/{tick,energy,congestion}` + `{Energy,World,Expedition}` models + `/api/game/{worlds,expedition,energy/refill}` handlers): spend Energy to send an expedition to one of 5 cube-worlds per 1-hour tick; at tick close each world's fixed CUBE pool is split among its explorers by effective weight (crowd-dilution congestion), credited via the idempotent settlement runner (`src/backend/expedition-settlement.ts`, started in `main.ts`). Two CUBE sinks ship here (refill, weight-boost); the faucet is gated for production until the third sink (tournament entry) lands. See `docs/ECONOMY.md` and the plan in `Journal/Projects/cube_worlds/plans/`.
 
 ## Security
 - Leaderboard pagination: limit 1–100, skip ≥ 0.
 - Random strings: `node:crypto.randomBytes`.
 
 ## Coverage (current)
-422 tests across 54 files. Run `npm run test:coverage` for the latest per-file line/branch/function report.
+477 tests across 65 files. Run `npm run test:coverage` for the latest per-file line/branch/function report.

--- a/src/backend/energy-handler.test.ts
+++ b/src/backend/energy-handler.test.ts
@@ -1,0 +1,52 @@
+/* eslint-disable test/no-import-node-test */
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { EnergyHandlerDependencies } from '#root/backend/energy-handler'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fastify from 'fastify'
+import { buildEnergyHandler } from '#root/backend/energy-handler'
+import { BalanceChangeType } from '#root/common/models/Balance'
+
+function makeDeps(overrides: Partial<EnergyHandlerDependencies> = {}) {
+  const calls = { addPoints: [] as Array<{ add: bigint, reason: BalanceChangeType }>, granted: [] as number[] }
+  const deps: EnergyHandlerDependencies = {
+    validateInitData: () => {},
+    parseInitData: () => ({ user: { id: 7 } }) as InitData,
+    findUserById: async (id) => (id === 7 ? ({ id: 7, _id: 'u7', votes: 10_000n } as any) : null),
+    addPoints: async (_id, add, reason) => { calls.addPoints.push({ add, reason }); return 9_500n },
+    grantEnergy: async (_u, amount) => { calls.granted.push(amount); return 90 + amount },
+    logError: () => {},
+    ...overrides,
+  }
+  return { deps, calls }
+}
+
+async function appWith(d: EnergyHandlerDependencies) {
+  const app = fastify()
+  await app.register(buildEnergyHandler(d), { prefix: '/api/game' })
+  return app
+}
+
+test('refill debits CUBE (Spend) and grants energy', async (t) => {
+  const { deps, calls } = makeDeps()
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/energy/refill', payload: { initData: 'x' } })
+  const body = res.json()
+  assert.equal(body.energy, 120) // 90 + 30
+  assert.equal(calls.addPoints[0].add, -500n)
+  assert.equal(calls.addPoints[0].reason, BalanceChangeType.Spend)
+  assert.deepEqual(calls.granted, [30])
+})
+
+test('refill rejected when the user cannot afford it (no energy granted)', async (t) => {
+  const { deps, calls } = makeDeps({
+    findUserById: async () => ({ id: 7, _id: 'u7', votes: 100n } as any),
+  })
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/energy/refill', payload: { initData: 'x' } })
+  assert.equal(res.json().error, 'Not enough CUBE')
+  assert.equal(calls.addPoints.length, 0)
+  assert.equal(calls.granted.length, 0)
+})

--- a/src/backend/energy-handler.ts
+++ b/src/backend/energy-handler.ts
@@ -1,0 +1,82 @@
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { FastifyInstance } from 'fastify'
+import { ClientError } from '#root/common/errors'
+import { REFILL_CUBE_COST, REFILL_ENERGY_AMOUNT } from '#root/common/helpers/energy'
+import { BalanceChangeType } from '#root/common/models/Balance'
+import { grantEnergy } from '#root/common/models/Energy'
+import { addPoints, findUserById } from '#root/common/models/User'
+import { logger } from '#root/logger'
+import { defaultParseInitData, defaultValidateInitData } from './init-data'
+import { safeErrorResponse } from './safe-error'
+
+interface Body {
+  initData: string
+}
+
+type ExistingUser = NonNullable<Awaited<ReturnType<typeof findUserById>>>
+
+export interface EnergyHandlerDependencies {
+  validateInitData: (initData: string) => void
+  parseInitData: (initData: string) => InitData
+  findUserById: (id: number) => Promise<ExistingUser | null>
+  addPoints: (userId: number, add: bigint, reason: BalanceChangeType) => Promise<bigint>
+  grantEnergy: (user: ExistingUser, amount: number) => Promise<number>
+  logError: (message: string) => void
+}
+
+function createDefaultDependencies(): EnergyHandlerDependencies {
+  return {
+    validateInitData: defaultValidateInitData,
+    parseInitData: defaultParseInitData,
+    findUserById,
+    addPoints,
+    grantEnergy: (user, amount) => grantEnergy(user, amount),
+    logError: logger.error.bind(logger),
+  }
+}
+
+async function findUserByInitData(initData: string, deps: EnergyHandlerDependencies) {
+  deps.validateInitData(initData)
+  const parsed = deps.parseInitData(initData)
+  const tgUserId = parsed?.user?.id
+  if (!tgUserId) throw new ClientError('Invalid telegram user id')
+  const user = await deps.findUserById(tgUserId)
+  if (!user) throw new ClientError('User not found in database')
+  return user
+}
+
+const bodySchema = {
+  schema: { body: { type: 'object', properties: { initData: { type: 'string', maxLength: 8192 } } } },
+  attachValidation: true,
+} as const
+
+export function buildEnergyHandler(
+  deps: EnergyHandlerDependencies = createDefaultDependencies(),
+) {
+  return async function energyHandler(fastify: FastifyInstance) {
+    fastify.post<{ Body: Body }>('/energy/refill', bodySchema, async (request) => {
+      if (request.validationError) return { error: 'Invalid request body' }
+      const { initData } = request.body
+      if (!initData) return { error: 'No initData provided' }
+      try {
+        const user = await findUserByInitData(initData, deps)
+        if (user.votes < BigInt(REFILL_CUBE_COST)) {
+          throw new ClientError('Not enough CUBE')
+        }
+        await deps.addPoints(user.id, -BigInt(REFILL_CUBE_COST), BalanceChangeType.Spend)
+        const energy = await deps.grantEnergy(user, REFILL_ENERGY_AMOUNT)
+        return {
+          energy,
+          spent: REFILL_CUBE_COST,
+          message: `Refilled ${REFILL_ENERGY_AMOUNT} energy`,
+        }
+      } catch (err) {
+        return safeErrorResponse(err, deps.logError)
+      }
+    })
+  }
+}
+
+const energyHandler = buildEnergyHandler()
+
+export default energyHandler

--- a/src/backend/energy-handler.ts
+++ b/src/backend/energy-handler.ts
@@ -60,6 +60,13 @@ export function buildEnergyHandler(
       if (!initData) return { error: 'No initData provided' }
       try {
         const user = await findUserByInitData(initData, deps)
+        // KNOWN MVP GAP: this affordability check reads a snapshot of votes and
+        // the debit below is a non-atomic $inc, so two refills fired in the same
+        // instant could both pass and drive the balance negative. Unlike the
+        // expedition handler, there is no energy-CAS gate here to serialize
+        // them. Accepted for MVP (the whole faucet is gated behind Plan 3's
+        // release gate); Plan 2 replaces this with an atomic guarded debit /
+        // reconciliation. Rate limiting (20/min) bounds the blast radius.
         if (user.votes < BigInt(REFILL_CUBE_COST)) {
           throw new ClientError('Not enough CUBE')
         }

--- a/src/backend/expedition-handler.test.ts
+++ b/src/backend/expedition-handler.test.ts
@@ -68,6 +68,8 @@ test('a CUBE weight-boost debits CUBE (Spend) and raises weight', async (t) => {
   assert.equal(body.weight, 36) // 30 + floor(600/100)
   assert.equal(calls.addPoints[0].add, -600n)
   assert.equal(calls.addPoints[0].reason, BalanceChangeType.Spend)
+  // the boosted weight (not the bare energy cost) must reach the crowd counter
+  assert.deepEqual(calls.commitments, [{ worldId: 'frostvault', weight: 36 }])
 })
 
 test('rejects a boost the user cannot afford', async (t) => {

--- a/src/backend/expedition-handler.test.ts
+++ b/src/backend/expedition-handler.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable test/no-import-node-test */
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { ExpeditionHandlerDependencies } from '#root/backend/expedition-handler'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fastify from 'fastify'
+import { buildExpeditionHandler } from '#root/backend/expedition-handler'
+import { BalanceChangeType } from '#root/common/models/Balance'
+
+function makeDeps(overrides: Partial<ExpeditionHandlerDependencies> = {}) {
+  const calls = {
+    spent: [] as number[],
+    addPoints: [] as Array<{ add: bigint, reason: BalanceChangeType }>,
+    commitments: [] as Array<{ worldId: string, weight: number }>,
+    created: [] as any[],
+  }
+  const deps: ExpeditionHandlerDependencies = {
+    validateInitData: () => {},
+    parseInitData: () => ({ user: { id: 7 } }) as InitData,
+    findUserById: async (id) => (id === 7 ? ({ id: 7, _id: 'u7', votes: 10_000n } as any) : null),
+    currentTickId: () => 100,
+    ensureWorldsForTick: async () => {},
+    findWorld: async (_t, worldId) => (worldId === 'frostvault' ? ({ worldId } as any) : null),
+    findOrCreateEnergy: async () => ({ current: 90 } as any),
+    spendEnergy: async (_e, amount) => { calls.spent.push(amount); return { current: 90 - amount } as any },
+    addPoints: async (_id, add, reason) => { calls.addPoints.push({ add, reason }); return 9_400n },
+    createExpedition: async (input) => { calls.created.push(input); return { _id: 'e1', ...input } as any },
+    addWorldCommitment: async (_t, worldId, weight) => { calls.commitments.push({ worldId, weight }) },
+    logError: () => {},
+    ...overrides,
+  }
+  return { deps, calls }
+}
+
+async function appWith(d: ExpeditionHandlerDependencies) {
+  const app = fastify()
+  await app.register(buildExpeditionHandler(d), { prefix: '/api/game' })
+  return app
+}
+
+test('sends an expedition: spends energy, records commitment, bumps crowd', async (t) => {
+  const { deps, calls } = makeDeps()
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'frostvault', risk: 'safe' },
+  })
+  const body = res.json()
+  assert.equal(body.worldId, 'frostvault')
+  assert.equal(body.weight, 30) // energy cost only, no boost
+  assert.deepEqual(calls.spent, [30])
+  assert.deepEqual(calls.commitments, [{ worldId: 'frostvault', weight: 30 }])
+  assert.equal(calls.addPoints.length, 0) // no boost -> no CUBE sink
+})
+
+test('a CUBE weight-boost debits CUBE (Spend) and raises weight', async (t) => {
+  const { deps, calls } = makeDeps()
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'frostvault', risk: 'greedy', cubeBoost: 600 },
+  })
+  const body = res.json()
+  assert.equal(body.weight, 36) // 30 + floor(600/100)
+  assert.equal(calls.addPoints[0].add, -600n)
+  assert.equal(calls.addPoints[0].reason, BalanceChangeType.Spend)
+})
+
+test('rejects a boost the user cannot afford', async (t) => {
+  const { deps } = makeDeps({
+    findUserById: async () => ({ id: 7, _id: 'u7', votes: 100n } as any),
+  })
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'frostvault', risk: 'safe', cubeBoost: 600 },
+  })
+  assert.equal(res.json().error, 'Not enough CUBE')
+})
+
+test('rejects an unknown world', async (t) => {
+  const { deps } = makeDeps()
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'nope', risk: 'safe' },
+  })
+  assert.equal(res.json().error, 'Unknown world')
+})
+
+test('rejects an invalid risk value', async (t) => {
+  const { deps } = makeDeps()
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'frostvault', risk: 'reckless' },
+  })
+  assert.equal(res.json().error, 'Invalid request body')
+})
+
+test('translates a duplicate-tick commitment into a friendly error', async (t) => {
+  const { deps } = makeDeps({
+    createExpedition: async () => { throw Object.assign(new Error('dup key'), { code: 11000 }) },
+  })
+  const app = await appWith(deps)
+  t.after(() => app.close())
+  const res = await app.inject({
+    method: 'POST',
+    url: '/api/game/expedition',
+    payload: { initData: 'x', worldId: 'frostvault', risk: 'safe' },
+  })
+  assert.equal(res.json().error, 'Already sent an expedition this tick')
+})

--- a/src/backend/expedition-handler.ts
+++ b/src/backend/expedition-handler.ts
@@ -122,12 +122,22 @@ export function buildExpeditionHandler(
 
         const energyDoc = await deps.findOrCreateEnergy(user)
         // Spend energy first (atomic CAS). If this throws, nothing else ran.
+        // The CAS also serializes concurrent same-user requests: only one wins
+        // the spend, so the unguarded addPoints debit below cannot double-fire
+        // for a single user/tick and drive the CUBE balance negative.
         await deps.spendEnergy(energyDoc, EXPEDITION_ENERGY_COST)
 
         // Debit the optional CUBE boost (sink).
         if (cubeBoost > 0) {
           await deps.addPoints(user.id, -BigInt(cubeBoost), BalanceChangeType.Spend)
         }
+
+        // MVP ordering trade-off (intentional, non-transactional): energy — and
+        // the CUBE boost above — are already spent by the time createExpedition
+        // can hit the unique (userId, tickId) index and reject a duplicate with
+        // E11000. A user only triggers this by racing themselves; the cost is a
+        // forfeited energy/CUBE spend, never a double commitment. A transactional
+        // version is deferred to Plan 2 (reconciliation).
 
         const weight = commitmentWeight(EXPEDITION_ENERGY_COST, cubeBoost)
         try {
@@ -147,6 +157,9 @@ export function buildExpeditionHandler(
           throw err
         }
 
+        // Live crowd counters only — the settlement runner recomputes weights
+        // from the actual expedition docs, so a failed bump here at worst blips
+        // the current tick's displayed board and never skews payouts.
         await deps.addWorldCommitment(tickId, worldId, weight)
 
         return {

--- a/src/backend/expedition-handler.ts
+++ b/src/backend/expedition-handler.ts
@@ -1,0 +1,169 @@
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { DocumentType } from '@typegoose/typegoose'
+import type { FastifyInstance } from 'fastify'
+import type { Risk } from '#root/common/helpers/congestion'
+import type { Energy } from '#root/common/models/Energy'
+import { ClientError } from '#root/common/errors'
+import { EXPEDITION_ENERGY_COST } from '#root/common/helpers/energy'
+import { currentTickId } from '#root/common/helpers/tick'
+import { BalanceChangeType } from '#root/common/models/Balance'
+import {
+  findOrCreateEnergy,
+  spendEnergy,
+} from '#root/common/models/Energy'
+import {
+  BOOST_CUBE_PER_WEIGHT,
+  commitmentWeight,
+  createExpedition,
+} from '#root/common/models/Expedition'
+import { addPoints, findUserById } from '#root/common/models/User'
+import { addWorldCommitment, ensureWorldsForTick, WorldModel } from '#root/common/models/World'
+import { logger } from '#root/logger'
+import { defaultParseInitData, defaultValidateInitData } from './init-data'
+import { safeErrorResponse } from './safe-error'
+
+interface Body {
+  initData: string
+  worldId: string
+  risk: Risk
+  cubeBoost?: number
+}
+
+type ExistingUser = NonNullable<Awaited<ReturnType<typeof findUserById>>>
+
+export interface ExpeditionHandlerDependencies {
+  validateInitData: (initData: string) => void
+  parseInitData: (initData: string) => InitData
+  findUserById: (id: number) => Promise<ExistingUser | null>
+  currentTickId: () => number
+  ensureWorldsForTick: (tickId: number) => Promise<void>
+  findWorld: (tickId: number, worldId: string) => Promise<{ worldId: string } | null>
+  findOrCreateEnergy: (user: ExistingUser) => Promise<DocumentType<Energy>>
+  spendEnergy: (energy: DocumentType<Energy>, amount: number) => Promise<{ current: number }>
+  addPoints: (userId: number, add: bigint, reason: BalanceChangeType) => Promise<bigint>
+  createExpedition: (input: {
+    userId: number
+    tickId: number
+    worldId: string
+    energySpent: number
+    cubeBoost: number
+    weight: number
+    risk: Risk
+  }) => Promise<{ _id: unknown }>
+  addWorldCommitment: (tickId: number, worldId: string, weight: number) => Promise<void>
+  logError: (message: string) => void
+}
+
+function createDefaultDependencies(): ExpeditionHandlerDependencies {
+  return {
+    validateInitData: defaultValidateInitData,
+    parseInitData: defaultParseInitData,
+    findUserById,
+    currentTickId: () => currentTickId(),
+    ensureWorldsForTick,
+    findWorld: (tickId, worldId) =>
+      WorldModel.findOne({ tickId, worldId }) as never,
+    findOrCreateEnergy,
+    spendEnergy: (energy, amount) => spendEnergy(energy, amount),
+    addPoints,
+    createExpedition: (input) => createExpedition(input) as never,
+    addWorldCommitment,
+    logError: logger.error.bind(logger),
+  }
+}
+
+async function findUserByInitData(initData: string, deps: ExpeditionHandlerDependencies) {
+  deps.validateInitData(initData)
+  const parsed = deps.parseInitData(initData)
+  const tgUserId = parsed?.user?.id
+  if (!tgUserId) throw new ClientError('Invalid telegram user id')
+  const user = await deps.findUserById(tgUserId)
+  if (!user) throw new ClientError('User not found in database')
+  return user
+}
+
+const bodySchema = {
+  schema: {
+    body: {
+      type: 'object',
+      properties: {
+        initData: { type: 'string', maxLength: 8192 },
+        worldId: { type: 'string', maxLength: 64 },
+        risk: { type: 'string', enum: ['safe', 'greedy'] },
+        cubeBoost: { type: 'integer', minimum: 0, maximum: 1_000_000_000 },
+      },
+    },
+  },
+  attachValidation: true,
+} as const
+
+export function buildExpeditionHandler(
+  deps: ExpeditionHandlerDependencies = createDefaultDependencies(),
+) {
+  return async function expeditionHandler(fastify: FastifyInstance) {
+    fastify.post<{ Body: Body }>('/expedition', bodySchema, async (request) => {
+      if (request.validationError) return { error: 'Invalid request body' }
+      const { initData, worldId, risk, cubeBoost = 0 } = request.body
+      if (!initData) return { error: 'No initData provided' }
+      if (!worldId || (risk !== 'safe' && risk !== 'greedy')) {
+        return { error: 'Invalid request body' }
+      }
+      try {
+        const user = await findUserByInitData(initData, deps)
+        const tickId = deps.currentTickId()
+        await deps.ensureWorldsForTick(tickId)
+
+        const world = await deps.findWorld(tickId, worldId)
+        if (!world) throw new ClientError('Unknown world')
+
+        if (cubeBoost > 0 && user.votes < BigInt(cubeBoost)) {
+          throw new ClientError('Not enough CUBE')
+        }
+
+        const energyDoc = await deps.findOrCreateEnergy(user)
+        // Spend energy first (atomic CAS). If this throws, nothing else ran.
+        await deps.spendEnergy(energyDoc, EXPEDITION_ENERGY_COST)
+
+        // Debit the optional CUBE boost (sink).
+        if (cubeBoost > 0) {
+          await deps.addPoints(user.id, -BigInt(cubeBoost), BalanceChangeType.Spend)
+        }
+
+        const weight = commitmentWeight(EXPEDITION_ENERGY_COST, cubeBoost)
+        try {
+          await deps.createExpedition({
+            userId: user.id,
+            tickId,
+            worldId,
+            energySpent: EXPEDITION_ENERGY_COST,
+            cubeBoost,
+            weight,
+            risk,
+          })
+        } catch (err) {
+          if ((err as { code?: number }).code === 11000) {
+            throw new ClientError('Already sent an expedition this tick')
+          }
+          throw err
+        }
+
+        await deps.addWorldCommitment(tickId, worldId, weight)
+
+        return {
+          worldId,
+          risk,
+          weight,
+          tickId,
+          cubeBoostPerWeight: BOOST_CUBE_PER_WEIGHT,
+          message: `Expedition sent to ${worldId}`,
+        }
+      } catch (err) {
+        return safeErrorResponse(err, deps.logError)
+      }
+    })
+  }
+}
+
+const expeditionHandler = buildExpeditionHandler()
+
+export default expeditionHandler

--- a/src/backend/expedition-settlement.test.ts
+++ b/src/backend/expedition-settlement.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable test/no-import-node-test */
+import type { SettlementDependencies } from '#root/backend/expedition-settlement'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildSettlementRunner } from '#root/backend/expedition-settlement'
+import { BalanceChangeType } from '#root/common/models/Balance'
+
+test('settles a closed world: splits pool and credits CUBE', async () => {
+  const credits: Array<{ userId: number, add: bigint, reason: BalanceChangeType }> = []
+  const settledExpeditions: Array<{ id: unknown, award: number }> = []
+  const settledWorlds: Array<{ tickId: number, worldId: string }> = []
+
+  const expeditions = [
+    { _id: 'e1', userId: 1, worldId: 'frostvault', weight: 30, risk: 'safe', riskRoll: 0, settled: false, credited: false, cubeAwarded: 0 },
+    { _id: 'e2', userId: 2, worldId: 'frostvault', weight: 30, risk: 'safe', riskRoll: 0, settled: false, credited: false, cubeAwarded: 0 },
+  ]
+
+  const deps: SettlementDependencies = {
+    currentTickId: () => 101,
+    findUnsettledWorlds: async () => [{ tickId: 100, worldId: 'frostvault', cubePool: 5000 } as any],
+    findUnsettledForWorld: async () => expeditions as any,
+    rollRisk: () => 0,
+    settleExpedition: async (id, award) => {
+      const e = expeditions.find((x) => x._id === id)!
+      e.settled = true
+      e.cubeAwarded = award
+      settledExpeditions.push({ id, award })
+      return true
+    },
+    markWorldSettled: async (tickId, worldId) => { settledWorlds.push({ tickId, worldId }) },
+    findSettledUncredited: async () => expeditions.filter((e) => e.settled && !e.credited) as any,
+    claimCredit: async (id) => {
+      const e = expeditions.find((x) => x._id === id)!
+      if (e.credited) return false
+      e.credited = true
+      return true
+    },
+    addPoints: async (userId, add, reason) => { credits.push({ userId, add, reason }); return add },
+    logInfo: () => {},
+    logError: () => {},
+  }
+
+  const runner = buildSettlementRunner(deps)
+  await runner.runOnce()
+
+  assert.deepEqual(settledExpeditions, [
+    { id: 'e1', award: 2500 },
+    { id: 'e2', award: 2500 },
+  ])
+  assert.deepEqual(settledWorlds, [{ tickId: 100, worldId: 'frostvault' }])
+  assert.equal(credits.length, 2)
+  assert.deepEqual(credits[0], { userId: 1, add: 2500n, reason: BalanceChangeType.Expedition })
+})
+
+test('is idempotent: a second run credits nobody twice', async () => {
+  const credits: bigint[] = []
+  const expeditions = [
+    { _id: 'e1', userId: 1, worldId: 'frostvault', weight: 30, risk: 'safe', riskRoll: 0, settled: true, credited: true, cubeAwarded: 2500 },
+  ]
+  const deps: SettlementDependencies = {
+    currentTickId: () => 101,
+    findUnsettledWorlds: async () => [],
+    findUnsettledForWorld: async () => [],
+    rollRisk: () => 0,
+    settleExpedition: async () => true,
+    markWorldSettled: async () => {},
+    findSettledUncredited: async () => expeditions.filter((e) => !e.credited) as any,
+    claimCredit: async () => false,
+    addPoints: async (_id, add) => { credits.push(add); return add },
+    logInfo: () => {},
+    logError: () => {},
+  }
+  const runner = buildSettlementRunner(deps)
+  await runner.runOnce()
+  assert.equal(credits.length, 0)
+})
+
+test('a CAS loss on credit skips the addPoints call', async () => {
+  const credits: bigint[] = []
+  const expeditions = [
+    { _id: 'e1', userId: 1, worldId: 'frostvault', weight: 30, risk: 'safe', riskRoll: 0, settled: true, credited: false, cubeAwarded: 2500 },
+  ]
+  const deps: SettlementDependencies = {
+    currentTickId: () => 101,
+    findUnsettledWorlds: async () => [],
+    findUnsettledForWorld: async () => [],
+    rollRisk: () => 0,
+    settleExpedition: async () => true,
+    markWorldSettled: async () => {},
+    findSettledUncredited: async () => expeditions as any,
+    claimCredit: async () => false, // lost the race to another runner
+    addPoints: async (_id, add) => { credits.push(add); return add },
+    logInfo: () => {},
+    logError: () => {},
+  }
+  const runner = buildSettlementRunner(deps)
+  await runner.runOnce()
+  assert.equal(credits.length, 0)
+})

--- a/src/backend/expedition-settlement.ts
+++ b/src/backend/expedition-settlement.ts
@@ -85,10 +85,20 @@ export function buildSettlementRunner(
       }
       await deps.markWorldSettled(world.tickId, world.worldId)
     }
+    if (worlds.length > 0) {
+      deps.logInfo(`Settlement: settled ${worlds.length} world(s) for ticks < ${tick}`)
+    }
   }
 
   // Second pass: credit balances for any settled-but-uncredited expedition.
   // claimCredit's CAS guarantees exactly one runner credits each row.
+  //
+  // Ordering is deliberate: claimCredit flips credited=true BEFORE addPoints
+  // runs. A crash in the gap therefore loses this expedition's CUBE (it stays
+  // credited=true, never re-selected) rather than risking a double-pay on the
+  // next run. For a soft-currency faucet that bias (prefer under-pay) is the
+  // safe one; the reconciliation worker in Plan 2 is the mechanism that
+  // detects and replays any such gap. Revisit before any hard-currency use.
   async function creditPass(): Promise<void> {
     const pending = await deps.findSettledUncredited()
     for (const e of pending) {

--- a/src/backend/expedition-settlement.ts
+++ b/src/backend/expedition-settlement.ts
@@ -1,0 +1,117 @@
+import type { Commitment } from '#root/common/helpers/congestion'
+import { settleWorld } from '#root/common/helpers/congestion'
+import { randomFloat } from '#root/common/helpers/random'
+import { currentTickId } from '#root/common/helpers/tick'
+import { BalanceChangeType } from '#root/common/models/Balance'
+import {
+  claimCredit,
+  findSettledUncredited,
+  findUnsettledForWorld,
+  settleExpedition,
+} from '#root/common/models/Expedition'
+import { addPoints } from '#root/common/models/User'
+import {
+  findUnsettledWorlds,
+  markWorldSettled,
+} from '#root/common/models/World'
+import { logger } from '#root/logger'
+
+interface SettlementWorld {
+  tickId: number
+  worldId: string
+  cubePool: number
+}
+
+interface SettlementExpedition {
+  _id: unknown
+  userId: number
+  worldId: string
+  weight: number
+  risk: Commitment['risk']
+}
+
+export interface SettlementDependencies {
+  currentTickId: () => number
+  findUnsettledWorlds: (currentTickId: number) => Promise<SettlementWorld[]>
+  findUnsettledForWorld: (tickId: number, worldId: string) => Promise<SettlementExpedition[]>
+  rollRisk: () => number
+  settleExpedition: (expeditionId: unknown, award: number) => Promise<boolean>
+  markWorldSettled: (tickId: number, worldId: string) => Promise<void>
+  findSettledUncredited: () => Promise<Array<{ _id: unknown, userId: number, cubeAwarded: number }>>
+  claimCredit: (expeditionId: unknown) => Promise<boolean>
+  addPoints: (userId: number, add: bigint, reason: BalanceChangeType) => Promise<bigint>
+  logInfo: (message: string) => void
+  logError: (message: string) => void
+}
+
+function createDefaultDependencies(): SettlementDependencies {
+  return {
+    currentTickId: () => currentTickId(),
+    findUnsettledWorlds: async (tick) =>
+      (await findUnsettledWorlds(tick)) as unknown as SettlementWorld[],
+    findUnsettledForWorld: async (tickId, worldId) =>
+      (await findUnsettledForWorld(tickId, worldId)) as unknown as SettlementExpedition[],
+    rollRisk: () => randomFloat(),
+    settleExpedition,
+    markWorldSettled,
+    findSettledUncredited: async () =>
+      (await findSettledUncredited()) as unknown as Array<{ _id: unknown, userId: number, cubeAwarded: number }>,
+    claimCredit,
+    addPoints,
+    logInfo: logger.info.bind(logger),
+    logError: logger.error.bind(logger),
+  }
+}
+
+export function buildSettlementRunner(
+  deps: SettlementDependencies = createDefaultDependencies(),
+) {
+  async function settlePass(): Promise<void> {
+    const tick = deps.currentTickId()
+    const worlds = await deps.findUnsettledWorlds(tick)
+    for (const world of worlds) {
+      const expeditions = await deps.findUnsettledForWorld(world.tickId, world.worldId)
+      const commitments: Commitment[] = expeditions.map((e) => ({
+        expeditionId: String(e._id),
+        weight: e.weight,
+        risk: e.risk,
+        riskRoll: deps.rollRisk(),
+      }))
+      const awards = settleWorld(world.cubePool, commitments)
+      const awardById = new Map(awards.map((a) => [a.expeditionId, a.award]))
+      for (const e of expeditions) {
+        const award = awardById.get(String(e._id)) ?? 0
+        await deps.settleExpedition(e._id, award)
+      }
+      await deps.markWorldSettled(world.tickId, world.worldId)
+    }
+  }
+
+  // Second pass: credit balances for any settled-but-uncredited expedition.
+  // claimCredit's CAS guarantees exactly one runner credits each row.
+  async function creditPass(): Promise<void> {
+    const pending = await deps.findSettledUncredited()
+    for (const e of pending) {
+      const won = await deps.claimCredit(e._id)
+      if (!won) continue
+      if (e.cubeAwarded > 0) {
+        try {
+          await deps.addPoints(e.userId, BigInt(e.cubeAwarded), BalanceChangeType.Expedition)
+        } catch (err) {
+          deps.logError(`Settlement credit failed for ${e.userId}: ${(err as Error).message}`)
+        }
+      }
+    }
+  }
+
+  async function runOnce(): Promise<void> {
+    await settlePass()
+    await creditPass()
+  }
+
+  return { runOnce }
+}
+
+const settlementRunner = buildSettlementRunner()
+
+export default settlementRunner

--- a/src/backend/worlds-handler.test.ts
+++ b/src/backend/worlds-handler.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable test/no-import-node-test */
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { WorldsHandlerDependencies } from '#root/backend/worlds-handler'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import fastify from 'fastify'
+import { buildWorldsHandler } from '#root/backend/worlds-handler'
+
+function deps(overrides: Partial<WorldsHandlerDependencies> = {}): WorldsHandlerDependencies {
+  return {
+    validateInitData: () => {},
+    parseInitData: () => ({ user: { id: 7 } }) as InitData,
+    findUserById: async (id) => (id === 7 ? ({ id: 7, _id: 'u7' } as any) : null),
+    findOrCreateEnergy: async () => ({ current: 90, regenAt: new Date(0) }) as any,
+    getEnergyStatus: () => ({ current: 90, max: 120, regenAt: new Date(0) }),
+    currentTickId: () => 100,
+    ensureWorldsForTick: async () => {},
+    findWorldsForTick: async () => [
+      { worldId: 'frostvault', name: 'Frostvault', cubePool: 5000, totalWeight: 30, explorerCount: 1 },
+    ] as any,
+    findMyExpeditionForTick: async () => null,
+    logError: () => {},
+    ...overrides,
+  }
+}
+
+async function appWith(d: WorldsHandlerDependencies) {
+  const app = fastify()
+  await app.register(buildWorldsHandler(d), { prefix: '/api/game' })
+  return app
+}
+
+test('POST /api/game/worlds returns board, energy, tick and no commitment', async (t) => {
+  const app = await appWith(deps())
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/worlds', payload: { initData: 'x' } })
+  const body = res.json()
+  assert.equal(body.tickId, 100)
+  assert.equal(body.energy.current, 90)
+  assert.equal(body.worlds.length, 1)
+  assert.equal(body.worlds[0].explorerCount, 1)
+  assert.equal(body.myExpedition, null)
+})
+
+test('POST /api/game/worlds surfaces an existing commitment', async (t) => {
+  const app = await appWith(deps({
+    findMyExpeditionForTick: async () => ({ worldId: 'emberwild', risk: 'greedy', weight: 36 }) as any,
+  }))
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/worlds', payload: { initData: 'x' } })
+  assert.equal(res.json().myExpedition.worldId, 'emberwild')
+})
+
+test('POST /api/game/worlds returns error when initData missing', async (t) => {
+  const app = await appWith(deps())
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/worlds', payload: {} })
+  assert.equal(res.json().error, 'No initData provided')
+})
+
+test('POST /api/game/worlds returns error for unknown user', async (t) => {
+  const app = await appWith(deps({ findUserById: async () => null }))
+  t.after(() => app.close())
+  const res = await app.inject({ method: 'POST', url: '/api/game/worlds', payload: { initData: 'x' } })
+  assert.equal(res.json().error, 'User not found in database')
+})

--- a/src/backend/worlds-handler.ts
+++ b/src/backend/worlds-handler.ts
@@ -1,0 +1,119 @@
+import type { InitData } from '@telegram-apps/init-data-node'
+import type { DocumentType } from '@typegoose/typegoose'
+import type { FastifyInstance } from 'fastify'
+import type { Energy } from '#root/common/models/Energy'
+import { ClientError } from '#root/common/errors'
+import { currentTickId } from '#root/common/helpers/tick'
+import {
+  findOrCreateEnergy,
+  getEnergyStatus,
+} from '#root/common/models/Energy'
+import { findMyExpeditionForTick } from '#root/common/models/Expedition'
+import { findUserById } from '#root/common/models/User'
+import { ensureWorldsForTick, findWorldsForTick } from '#root/common/models/World'
+import { logger } from '#root/logger'
+import { defaultParseInitData, defaultValidateInitData } from './init-data'
+import { safeErrorResponse } from './safe-error'
+
+interface Body {
+  initData: string
+}
+
+type ExistingUser = NonNullable<Awaited<ReturnType<typeof findUserById>>>
+
+export interface WorldsHandlerDependencies {
+  validateInitData: (initData: string) => void
+  parseInitData: (initData: string) => InitData
+  findUserById: (id: number) => Promise<ExistingUser | null>
+  findOrCreateEnergy: (user: ExistingUser) => Promise<DocumentType<Energy>>
+  getEnergyStatus: (energy: DocumentType<Energy>) => ReturnType<typeof getEnergyStatus>
+  currentTickId: () => number
+  ensureWorldsForTick: (tickId: number) => Promise<void>
+  findWorldsForTick: (tickId: number) => Promise<Array<{
+    worldId: string
+    name: string
+    cubePool: number
+    totalWeight: number
+    explorerCount: number
+  }>>
+  findMyExpeditionForTick: (
+    userId: number,
+    tickId: number,
+  ) => Promise<{ worldId: string, risk: string, weight: number } | null>
+  logError: (message: string) => void
+}
+
+function createDefaultDependencies(): WorldsHandlerDependencies {
+  return {
+    validateInitData: defaultValidateInitData,
+    parseInitData: defaultParseInitData,
+    findUserById,
+    findOrCreateEnergy,
+    getEnergyStatus,
+    currentTickId: () => currentTickId(),
+    ensureWorldsForTick,
+    findWorldsForTick: (tickId) => findWorldsForTick(tickId) as never,
+    findMyExpeditionForTick: (userId, tickId) =>
+      findMyExpeditionForTick(userId, tickId) as never,
+    logError: logger.error.bind(logger),
+  }
+}
+
+async function findUserByInitData(
+  initData: string,
+  deps: WorldsHandlerDependencies,
+) {
+  deps.validateInitData(initData)
+  const parsed = deps.parseInitData(initData)
+  const tgUserId = parsed?.user?.id
+  if (!tgUserId) throw new ClientError('Invalid telegram user id')
+  const user = await deps.findUserById(tgUserId)
+  if (!user) throw new ClientError('User not found in database')
+  return user
+}
+
+const bodySchema = {
+  schema: { body: { type: 'object', properties: { initData: { type: 'string', maxLength: 8192 } } } },
+  attachValidation: true,
+} as const
+
+export function buildWorldsHandler(
+  deps: WorldsHandlerDependencies = createDefaultDependencies(),
+) {
+  return async function worldsHandler(fastify: FastifyInstance) {
+    fastify.post<{ Body: Body }>('/worlds', bodySchema, async (request) => {
+      if (request.validationError) return { error: 'Invalid request body' }
+      const { initData } = request.body
+      if (!initData) return { error: 'No initData provided' }
+      try {
+        const user = await findUserByInitData(initData, deps)
+        const tickId = deps.currentTickId()
+        await deps.ensureWorldsForTick(tickId)
+        const energyDoc = await deps.findOrCreateEnergy(user)
+        const energy = deps.getEnergyStatus(energyDoc)
+        const worlds = await deps.findWorldsForTick(tickId)
+        const mine = await deps.findMyExpeditionForTick(user.id, tickId)
+        return {
+          tickId,
+          energy: { current: energy.current, max: energy.max },
+          worlds: worlds.map((w) => ({
+            worldId: w.worldId,
+            name: w.name,
+            cubePool: w.cubePool,
+            explorerCount: w.explorerCount,
+            totalWeight: w.totalWeight,
+          })),
+          myExpedition: mine
+            ? { worldId: mine.worldId, risk: mine.risk, weight: mine.weight }
+            : null,
+        }
+      } catch (err) {
+        return safeErrorResponse(err, deps.logError)
+      }
+    })
+  }
+}
+
+const worldsHandler = buildWorldsHandler()
+
+export default worldsHandler

--- a/src/common/helpers/congestion.test.ts
+++ b/src/common/helpers/congestion.test.ts
@@ -75,3 +75,14 @@ test('shares below the floor are raised to FLOOR_PAYOUT', () => {
   const awards = settleWorld(5, commitments) // 0.5 each -> floors to 0 -> raised to 1
   assert.ok(awards.every((a) => a.award === FLOOR_PAYOUT))
 })
+
+test('a world of all-zero-weight commitments still floors each to FLOOR_PAYOUT', () => {
+  const awards = settleWorld(5000, [
+    { expeditionId: 'a', weight: 0, risk: 'safe', riskRoll: 0 },
+    { expeditionId: 'b', weight: 0, risk: 'greedy', riskRoll: 1 },
+  ])
+  assert.deepEqual(awards, [
+    { expeditionId: 'a', award: FLOOR_PAYOUT },
+    { expeditionId: 'b', award: FLOOR_PAYOUT },
+  ])
+})

--- a/src/common/helpers/congestion.test.ts
+++ b/src/common/helpers/congestion.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  FLOOR_PAYOUT,
+  GREEDY_MAX_MULT,
+  GREEDY_MIN_MULT,
+  riskMultiplier,
+  settleWorld,
+} from '#root/common/helpers/congestion'
+
+test('greedy multiplier spans [0.4, 1.6] with mean 1.0', () => {
+  assert.equal(GREEDY_MIN_MULT, 0.4)
+  assert.equal(GREEDY_MAX_MULT, 1.6)
+  assert.equal(riskMultiplier('greedy', 0), 0.4)
+  assert.equal(riskMultiplier('greedy', 1), 1.6)
+  assert.equal(riskMultiplier('greedy', 0.5), 1.0)
+  assert.equal(riskMultiplier('safe', 0.5), 1.0) // roll ignored for safe
+})
+
+test('equal safe commitments split the pool evenly', () => {
+  const awards = settleWorld(5000, [
+    { expeditionId: 'a', weight: 30, risk: 'safe', riskRoll: 0 },
+    { expeditionId: 'b', weight: 30, risk: 'safe', riskRoll: 0 },
+  ])
+  assert.deepEqual(awards, [
+    { expeditionId: 'a', award: 2500 },
+    { expeditionId: 'b', award: 2500 },
+  ])
+})
+
+test('crowding thins each share — total never exceeds the pool', () => {
+  const commitments = Array.from({ length: 100 }, (_, i) => ({
+    expeditionId: String(i),
+    weight: 30,
+    risk: 'safe' as const,
+    riskRoll: 0,
+  }))
+  const awards = settleWorld(5000, commitments)
+  const total = awards.reduce((s, a) => s + a.award, 0)
+  assert.ok(total <= 5000, `total ${total} exceeded pool`)
+  assert.equal(awards[0].award, 50) // 5000 / 100
+})
+
+test('a winning greedy roll beats a safe peer of equal weight', () => {
+  const awards = settleWorld(1000, [
+    { expeditionId: 'greedy', weight: 30, risk: 'greedy', riskRoll: 1 }, // ×1.6
+    { expeditionId: 'safe', weight: 30, risk: 'safe', riskRoll: 0 }, // ×1.0
+  ])
+  const greedy = awards.find((a) => a.expeditionId === 'greedy')!.award
+  const safe = awards.find((a) => a.expeditionId === 'safe')!.award
+  assert.ok(greedy > safe)
+  assert.ok(greedy + safe <= 1000)
+})
+
+test('a lone explorer takes the whole pool', () => {
+  const awards = settleWorld(5000, [
+    { expeditionId: 'solo', weight: 30, risk: 'greedy', riskRoll: 0 },
+  ])
+  assert.deepEqual(awards, [{ expeditionId: 'solo', award: 5000 }])
+})
+
+test('an empty world mints nothing (faucet stays bounded)', () => {
+  assert.deepEqual(settleWorld(5000, []), [])
+})
+
+test('shares below the floor are raised to FLOOR_PAYOUT', () => {
+  assert.equal(FLOOR_PAYOUT, 1)
+  const commitments = Array.from({ length: 10 }, (_, i) => ({
+    expeditionId: String(i),
+    weight: 1,
+    risk: 'safe' as const,
+    riskRoll: 0,
+  }))
+  const awards = settleWorld(5, commitments) // 0.5 each -> floors to 0 -> raised to 1
+  assert.ok(awards.every((a) => a.award === FLOOR_PAYOUT))
+})

--- a/src/common/helpers/congestion.ts
+++ b/src/common/helpers/congestion.ts
@@ -1,0 +1,48 @@
+export type Risk = 'safe' | 'greedy'
+
+// Greedy spans [0.4, 1.6] so its mean is exactly 1.0 — greedy redistributes a
+// world's pool between players without changing the total minted, keeping the
+// faucet bounded. Safe is a flat 1.0.
+export const GREEDY_MIN_MULT = 0.4
+export const GREEDY_MAX_MULT = 1.6
+export const FLOOR_PAYOUT = 1
+
+export interface Commitment {
+  expeditionId: string
+  // energy spent + any CUBE-boost weight, computed by the caller
+  weight: number
+  risk: Risk
+  // uniform [0, 1] roll, injected for determinism/testability
+  riskRoll: number
+}
+
+export interface Award {
+  expeditionId: string
+  award: number
+}
+
+export function riskMultiplier(risk: Risk, riskRoll: number): number {
+  if (risk === 'safe') return 1
+  const clamped = Math.min(1, Math.max(0, riskRoll))
+  return GREEDY_MIN_MULT + clamped * (GREEDY_MAX_MULT - GREEDY_MIN_MULT)
+}
+
+// Divide a world's fixed CUBE pool among its commitments by effective weight
+// (weight × risk multiplier). Total awarded is <= pool (floor rounding only
+// reduces it); the per-share FLOOR_PAYOUT guarantees a participant never gets
+// zero. An empty world mints nothing.
+export function settleWorld(pool: number, commitments: Commitment[]): Award[] {
+  if (commitments.length === 0) return []
+  const effective = commitments.map((c) => ({
+    expeditionId: c.expeditionId,
+    eff: Math.max(0, c.weight) * riskMultiplier(c.risk, c.riskRoll),
+  }))
+  const totalEff = effective.reduce((s, e) => s + e.eff, 0)
+  if (totalEff <= 0) {
+    return commitments.map((c) => ({ expeditionId: c.expeditionId, award: FLOOR_PAYOUT }))
+  }
+  return effective.map((e) => ({
+    expeditionId: e.expeditionId,
+    award: Math.max(FLOOR_PAYOUT, Math.floor((pool * e.eff) / totalEff)),
+  }))
+}

--- a/src/common/helpers/congestion.ts
+++ b/src/common/helpers/congestion.ts
@@ -28,9 +28,17 @@ export function riskMultiplier(risk: Risk, riskRoll: number): number {
 }
 
 // Divide a world's fixed CUBE pool among its commitments by effective weight
-// (weight × risk multiplier). Total awarded is <= pool (floor rounding only
-// reduces it); the per-share FLOOR_PAYOUT guarantees a participant never gets
-// zero. An empty world mints nothing.
+// (weight × risk multiplier). An empty world mints nothing.
+//
+// Bound: proportional shares sum to <= pool (floor rounding only reduces the
+// total). The per-share FLOOR_PAYOUT — which guarantees a participant never
+// gets zero ("positive numbers") — is the ONE thing that can push the total
+// slightly above pool: the true ceiling is `pool + n*FLOOR_PAYOUT`. With the
+// minimum real commitment weight (one expedition = 30 energy) the proportional
+// share only drops below FLOOR_PAYOUT once a single world holds more explorers
+// than its pool (>~5000 at POOL_PER_WORLD=5000) within one tick, so at MVP
+// scale the practical bound is pool. Production pool sizing (Plan 3) must
+// account for the floor at extreme crowding.
 export function settleWorld(pool: number, commitments: Commitment[]): Award[] {
   if (commitments.length === 0) return []
   const effective = commitments.map((c) => ({

--- a/src/common/helpers/energy.test.ts
+++ b/src/common/helpers/energy.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ENERGY_MAX,
+  ENERGY_REGEN_INTERVAL_MS,
+  EXPEDITION_ENERGY_COST,
+  REFILL_CUBE_COST,
+  REFILL_ENERGY_AMOUNT,
+  regenEnergy,
+} from '#root/common/helpers/energy'
+
+test('constants have the agreed MVP values', () => {
+  assert.equal(ENERGY_MAX, 120)
+  assert.equal(EXPEDITION_ENERGY_COST, 30)
+  // +10 energy/hour => one point every 6 minutes
+  assert.equal(ENERGY_REGEN_INTERVAL_MS, 360_000)
+  assert.equal(REFILL_CUBE_COST, 500)
+  assert.equal(REFILL_ENERGY_AMOUNT, 30)
+})
+
+test('regenEnergy adds whole points for elapsed intervals, capped at max', () => {
+  const last = new Date(0)
+  // 0 elapsed -> unchanged
+  assert.deepEqual(regenEnergy(50, last, new Date(0)), { current: 50, regenAt: last })
+  // 3 intervals elapsed (18 min) -> +3
+  const after18 = regenEnergy(50, last, new Date(18 * 60 * 1000))
+  assert.equal(after18.current, 53)
+  assert.equal(after18.regenAt.getTime(), 18 * 60 * 1000)
+  // partial interval does not advance regenAt past the consumed whole intervals
+  const after20 = regenEnergy(50, last, new Date(20 * 60 * 1000))
+  assert.equal(after20.current, 53) // still 3 whole intervals
+  assert.equal(after20.regenAt.getTime(), 18 * 60 * 1000) // 2 min remainder carried
+})
+
+test('regenEnergy never exceeds ENERGY_MAX and freezes regenAt at the cap', () => {
+  const result = regenEnergy(119, new Date(0), new Date(10 * 60 * 60 * 1000))
+  assert.equal(result.current, ENERGY_MAX)
+  // once capped, regenAt jumps to now so no "banked" overflow is granted later
+  assert.equal(result.regenAt.getTime(), 10 * 60 * 60 * 1000)
+})
+
+test('regenEnergy leaves an already-capped balance untouched', () => {
+  const now = new Date(5_000_000)
+  const result = regenEnergy(ENERGY_MAX, new Date(0), now)
+  assert.equal(result.current, ENERGY_MAX)
+  assert.equal(result.regenAt.getTime(), now.getTime())
+})

--- a/src/common/helpers/energy.ts
+++ b/src/common/helpers/energy.ts
@@ -1,0 +1,38 @@
+export const ENERGY_MAX = 120
+export const EXPEDITION_ENERGY_COST = 30
+// +10 energy per hour => one energy point every 6 minutes.
+export const ENERGY_REGEN_INTERVAL_MS = (60 * 60 * 1000) / 10
+// CUBE sink: spend REFILL_CUBE_COST CUBE to gain REFILL_ENERGY_AMOUNT energy.
+export const REFILL_CUBE_COST = 500
+export const REFILL_ENERGY_AMOUNT = 30
+
+export interface RegenResult {
+  current: number
+  regenAt: Date
+}
+
+// Lazily compute regenerated energy. Stores back only the whole intervals that
+// were consumed: a partial interval's remainder is preserved by advancing
+// regenAt by the consumed whole intervals, not all the way to `now`. Once the
+// balance is at (or over) the cap, regenAt jumps to `now` so no overflow is
+// banked for later.
+export function regenEnergy(
+  current: number,
+  regenAt: Date,
+  now: Date = new Date(),
+): RegenResult {
+  if (current >= ENERGY_MAX) {
+    return { current: ENERGY_MAX, regenAt: now }
+  }
+  const elapsed = Math.max(0, now.getTime() - regenAt.getTime())
+  const earned = Math.floor(elapsed / ENERGY_REGEN_INTERVAL_MS)
+  if (earned <= 0) {
+    return { current, regenAt }
+  }
+  const next = current + earned
+  if (next >= ENERGY_MAX) {
+    return { current: ENERGY_MAX, regenAt: now }
+  }
+  const consumedMs = earned * ENERGY_REGEN_INTERVAL_MS
+  return { current: next, regenAt: new Date(regenAt.getTime() + consumedMs) }
+}

--- a/src/common/helpers/random.test.ts
+++ b/src/common/helpers/random.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable test/no-import-node-test */
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { generateRandomString } from '#root/common/helpers/random'
+import { generateRandomString, randomFloat } from '#root/common/helpers/random'
 
 test('generateRandomString returns a string of the requested length', () => {
   for (const length of [1, 8, 16, 32, 64]) {
@@ -21,4 +21,12 @@ test('generateRandomString returns different values across calls (overwhelmingly
   const samples = new Set<string>()
   for (let i = 0; i < 50; i++) samples.add(generateRandomString(32))
   assert.equal(samples.size, 50)
+})
+
+test('randomFloat returns values in [0, 1) across 1000 draws', () => {
+  for (let i = 0; i < 1000; i++) {
+    const v = randomFloat()
+    assert.ok(v >= 0, `expected >= 0, got ${v}`)
+    assert.ok(v < 1, `expected < 1, got ${v}`)
+  }
 })

--- a/src/common/helpers/random.ts
+++ b/src/common/helpers/random.ts
@@ -9,3 +9,9 @@ export function generateRandomString(length: number): string {
     .replaceAll('/', '_')
     .replaceAll('=', '')
 }
+
+// Uniform float in [0, 1) backed by crypto randomness — used for the greedy
+// risk roll in expedition settlement.
+export function randomFloat(): number {
+  return randomBytes(4).readUInt32BE(0) / 0x1_0000_0000
+}

--- a/src/common/helpers/tick.test.ts
+++ b/src/common/helpers/tick.test.ts
@@ -1,0 +1,25 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { currentTickId, isTickClosed, TICK_MS, tickEnd, tickStart } from '#root/common/helpers/tick'
+
+test('TICK_MS is one hour', () => {
+  assert.equal(TICK_MS, 3_600_000)
+})
+
+test('currentTickId floors epoch ms into hour buckets', () => {
+  assert.equal(currentTickId(new Date(0)), 0)
+  assert.equal(currentTickId(new Date(3_599_999)), 0)
+  assert.equal(currentTickId(new Date(3_600_000)), 1)
+  assert.equal(currentTickId(new Date(7_200_001)), 2)
+})
+
+test('tickStart and tickEnd bracket the tick', () => {
+  assert.equal(tickStart(2).getTime(), 7_200_000)
+  assert.equal(tickEnd(2).getTime(), 10_800_000)
+})
+
+test('isTickClosed is true only once now reaches the next tick', () => {
+  assert.equal(isTickClosed(0, new Date(3_599_999)), false)
+  assert.equal(isTickClosed(0, new Date(3_600_000)), true)
+})

--- a/src/common/helpers/tick.ts
+++ b/src/common/helpers/tick.ts
@@ -1,0 +1,21 @@
+// A tick is a fixed 1-hour window. tickId = floor(epochMs / TICK_MS), so the
+// current tick is derivable from the clock alone and no tick table is stored.
+export const TICK_MS = 60 * 60 * 1000
+
+export function currentTickId(now: Date = new Date()): number {
+  return Math.floor(now.getTime() / TICK_MS)
+}
+
+export function tickStart(tickId: number): Date {
+  return new Date(tickId * TICK_MS)
+}
+
+export function tickEnd(tickId: number): Date {
+  return new Date((tickId + 1) * TICK_MS)
+}
+
+// A tick is settleable once wall-clock time has reached the start of the
+// following tick.
+export function isTickClosed(tickId: number, now: Date = new Date()): boolean {
+  return now.getTime() >= tickEnd(tickId).getTime()
+}

--- a/src/common/models/Balance.test.ts
+++ b/src/common/models/Balance.test.ts
@@ -36,3 +36,8 @@ test('getBalanceChangeTypeName falls back to Unknown for missing values', () => 
   assert.equal(getBalanceChangeTypeName(999 as BalanceChangeType), 'Unknown')
   assert.equal(getBalanceChangeTypeName(-2 as BalanceChangeType), 'Unknown')
 })
+
+test('getBalanceChangeTypeName maps the expedition-loop types', () => {
+  assert.equal(getBalanceChangeTypeName(BalanceChangeType.Expedition), 'Expedition')
+  assert.equal(getBalanceChangeTypeName(BalanceChangeType.Spend), 'Spend')
+})

--- a/src/common/models/Balance.ts
+++ b/src/common/models/Balance.ts
@@ -14,6 +14,8 @@ export enum BalanceChangeType {
   Task = 6,
   Claim = 7,
   Trade = 8, // for $SATOSHI
+  Expedition = 9, // CUBE faucet: expedition payout
+  Spend = 10, // CUBE sink: energy refill / weight-boost
 }
 
 export function getBalanceChangeTypeName(

--- a/src/common/models/Energy.test.ts
+++ b/src/common/models/Energy.test.ts
@@ -1,0 +1,53 @@
+/* eslint-disable test/no-import-node-test */
+import type { DocumentType } from '@typegoose/typegoose'
+import type { Energy } from '#root/common/models/Energy'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { ClientError } from '#root/common/errors'
+import { ENERGY_MAX } from '#root/common/helpers/energy'
+import { getEnergyStatus, spendEnergy } from '#root/common/models/Energy'
+
+function fakeEnergy(current: number, regenAt: Date): DocumentType<Energy> {
+  return { current, regenAt } as unknown as DocumentType<Energy>
+}
+
+test('getEnergyStatus reports the lazily-regenerated balance', () => {
+  const status = getEnergyStatus(fakeEnergy(50, new Date(0)), new Date(18 * 60 * 1000))
+  assert.equal(status.current, 53)
+  assert.equal(status.max, ENERGY_MAX)
+})
+
+test('spendEnergy deducts and persists when affordable', async () => {
+  const energy = fakeEnergy(100, new Date(0))
+  const writes: Array<{ current: number }> = []
+  const result = await spendEnergy(energy, 30, new Date(0), async (_e, _prev, update) => {
+    writes.push({ current: update.current })
+    return true
+  })
+  assert.equal(result.current, 70)
+  assert.equal(writes[0].current, 70)
+  assert.equal(energy.current, 70) // in-memory doc updated on success
+})
+
+test('spendEnergy regenerates before checking affordability', async () => {
+  // 20 energy + 18 minutes (=+3) = 23, enough for a 22 spend
+  const energy = fakeEnergy(20, new Date(0))
+  const result = await spendEnergy(energy, 22, new Date(18 * 60 * 1000), async () => true)
+  assert.equal(result.current, 1)
+})
+
+test('spendEnergy throws ClientError when unaffordable', async () => {
+  const energy = fakeEnergy(10, new Date(0))
+  await assert.rejects(
+    () => spendEnergy(energy, 30, new Date(0), async () => true),
+    (err) => err instanceof ClientError,
+  )
+})
+
+test('spendEnergy throws when it loses the compare-and-swap race', async () => {
+  const energy = fakeEnergy(100, new Date(0))
+  await assert.rejects(
+    () => spendEnergy(energy, 30, new Date(0), async () => false),
+    (err) => err instanceof ClientError,
+  )
+})

--- a/src/common/models/Energy.ts
+++ b/src/common/models/Energy.ts
@@ -22,9 +22,10 @@ const EnergyModel = getModelForClass(Energy)
 
 export { EnergyModel }
 
+// regenAt is set inline at insert time (not here) so the timestamp reflects
+// the moment of creation, never module-load time.
 const ENERGY_DEFAULTS = {
   current: ENERGY_MAX,
-  regenAt: new Date(),
 }
 
 // Atomic upsert — same E11000-recovery shape as findOrCreateClaim.

--- a/src/common/models/Energy.ts
+++ b/src/common/models/Energy.ts
@@ -1,0 +1,123 @@
+import type { DocumentType, Ref } from '@typegoose/typegoose'
+import type { UserDoc } from './User'
+import { getModelForClass, modelOptions, prop } from '@typegoose/typegoose'
+import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+import { ClientError } from '#root/common/errors'
+import { ENERGY_MAX, regenEnergy } from '#root/common/helpers/energy'
+import { User } from './User'
+
+@modelOptions({ schemaOptions: { timestamps: true } })
+export class Energy extends TimeStamps {
+  @prop({ ref: () => User, required: true, unique: true, index: true })
+  user!: Ref<User>
+
+  @prop({ type: Number, required: true, default: ENERGY_MAX })
+  current!: number
+
+  @prop({ type: Date, required: true, default: () => new Date() })
+  regenAt!: Date
+}
+
+const EnergyModel = getModelForClass(Energy)
+
+export { EnergyModel }
+
+const ENERGY_DEFAULTS = {
+  current: ENERGY_MAX,
+  regenAt: new Date(),
+}
+
+// Atomic upsert — same E11000-recovery shape as findOrCreateClaim.
+export async function findOrCreateEnergy(
+  user: UserDoc,
+): Promise<DocumentType<Energy>> {
+  try {
+    const energy = await EnergyModel.findOneAndUpdate(
+      { user: user._id },
+      { $setOnInsert: { user: user._id, ...ENERGY_DEFAULTS, regenAt: new Date() } },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    )
+    if (energy) return energy as DocumentType<Energy>
+  } catch (err) {
+    if ((err as { code?: number }).code !== 11000) throw err
+  }
+  const existing = await EnergyModel.findOne({ user: user._id })
+  if (!existing) {
+    throw new Error('Energy record disappeared after duplicate-key recovery')
+  }
+  return existing as DocumentType<Energy>
+}
+
+export function getEnergyStatus(energy: DocumentType<Energy>, now: Date = new Date()) {
+  const regen = regenEnergy(energy.current, energy.regenAt, now)
+  return {
+    current: regen.current,
+    max: ENERGY_MAX,
+    regenAt: regen.regenAt,
+  }
+}
+
+export interface EnergyUpdateFields {
+  current: number
+  regenAt: Date
+}
+
+export type EnergyPersist = (
+  energy: DocumentType<Energy>,
+  expectedRegenAt: Date,
+  update: EnergyUpdateFields,
+) => Promise<boolean>
+
+// Compare-and-swap on regenAt: serializes concurrent spends per user the same
+// way persistClaimAtomic does on lastClaimDate.
+const persistEnergyAtomic: EnergyPersist = async (energy, expectedRegenAt, update) => {
+  const result = await EnergyModel.findOneAndUpdate(
+    { _id: energy._id, regenAt: expectedRegenAt },
+    { $set: update },
+    { new: false },
+  )
+  return result !== null
+}
+
+// Deducts `amount` energy after regenerating. Throws ClientError if the
+// regenerated balance is insufficient or the CAS is lost.
+export async function spendEnergy(
+  energy: DocumentType<Energy>,
+  amount: number,
+  now: Date = new Date(),
+  persist: EnergyPersist = persistEnergyAtomic,
+): Promise<EnergyUpdateFields> {
+  const regen = regenEnergy(energy.current, energy.regenAt, now)
+  if (regen.current < amount) {
+    throw new ClientError('Not enough energy')
+  }
+  const previousRegenAt = energy.regenAt
+  const update: EnergyUpdateFields = {
+    current: regen.current - amount,
+    regenAt: regen.regenAt,
+  }
+  const won = await persist(energy, previousRegenAt, update)
+  if (!won) {
+    throw new ClientError('Energy changed, please retry')
+  }
+  energy.current = update.current
+  energy.regenAt = update.regenAt
+  return update
+}
+
+// Grants energy (capped) — used by the CUBE-refill sink. Best-effort, not
+// part of the spend CAS.
+export async function grantEnergy(
+  user: UserDoc,
+  amount: number,
+  now: Date = new Date(),
+): Promise<number> {
+  const energy = await findOrCreateEnergy(user)
+  const regen = regenEnergy(energy.current, energy.regenAt, now)
+  const next = Math.min(ENERGY_MAX, regen.current + amount)
+  await EnergyModel.updateOne(
+    { _id: energy._id },
+    { $set: { current: next, regenAt: regen.regenAt } },
+  )
+  return next
+}

--- a/src/common/models/Expedition.test.ts
+++ b/src/common/models/Expedition.test.ts
@@ -1,0 +1,13 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { commitmentWeight } from '#root/common/models/Expedition'
+
+test('commitmentWeight adds the CUBE-boost weight to energy spent', () => {
+  // base energy 30, no boost
+  assert.equal(commitmentWeight(30, 0), 30)
+  // 600 CUBE boost / 100 CUBE-per-weight = +6 weight
+  assert.equal(commitmentWeight(30, 600), 36)
+  // sub-threshold boost rounds down
+  assert.equal(commitmentWeight(30, 150), 31)
+})

--- a/src/common/models/Expedition.ts
+++ b/src/common/models/Expedition.ts
@@ -1,0 +1,108 @@
+import type { DocumentType } from '@typegoose/typegoose'
+import type { Risk } from '#root/common/helpers/congestion'
+import { getModelForClass, index, modelOptions, prop } from '@typegoose/typegoose'
+import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+
+// CUBE-boost sink conversion: this many CUBE buys one unit of world weight.
+export const BOOST_CUBE_PER_WEIGHT = 100
+
+// Effective weight a commitment carries into the congestion split.
+export function commitmentWeight(energySpent: number, cubeBoost: number): number {
+  return energySpent + Math.floor(Math.max(0, cubeBoost) / BOOST_CUBE_PER_WEIGHT)
+}
+
+// One expedition per user per tick — unique compound index, declared at schema
+// level so Mongoose surfaces index errors through the normal boot flow.
+@index({ userId: 1, tickId: 1 }, { unique: true })
+@modelOptions({ schemaOptions: { timestamps: true } })
+export class Expedition extends TimeStamps {
+  @prop({ type: Number, required: true, index: true })
+  userId!: number
+
+  @prop({ type: Number, required: true, index: true })
+  tickId!: number
+
+  @prop({ type: String, required: true })
+  worldId!: string
+
+  @prop({ type: Number, required: true })
+  energySpent!: number
+
+  @prop({ type: Number, required: true, default: 0 })
+  cubeBoost!: number
+
+  @prop({ type: Number, required: true })
+  weight!: number
+
+  @prop({ type: String, required: true })
+  risk!: Risk
+
+  @prop({ type: Boolean, required: true, default: false, index: true })
+  settled!: boolean
+
+  @prop({ type: Number, required: true, default: 0 })
+  cubeAwarded!: number
+
+  @prop({ type: Boolean, required: true, default: false, index: true })
+  credited!: boolean
+}
+
+const ExpeditionModel = getModelForClass(Expedition)
+
+export { ExpeditionModel }
+
+export interface CreateExpeditionInput {
+  userId: number
+  tickId: number
+  worldId: string
+  energySpent: number
+  cubeBoost: number
+  weight: number
+  risk: Risk
+}
+
+// Throws E11000 if the user already committed this tick — callers translate
+// that into a ClientError.
+export async function createExpedition(
+  input: CreateExpeditionInput,
+): Promise<DocumentType<Expedition>> {
+  return ExpeditionModel.create({ ...input, settled: false, cubeAwarded: 0, credited: false }) as unknown as Promise<DocumentType<Expedition>>
+}
+
+export function findMyExpeditionForTick(userId: number, tickId: number) {
+  return ExpeditionModel.findOne({ userId, tickId })
+}
+
+export function findUnsettledForWorld(tickId: number, worldId: string) {
+  return ExpeditionModel.find({ tickId, worldId, settled: false })
+}
+
+// CAS: flip settled false->true and record the award in one update. Returns
+// true only for the runner that won the flip, so settlement can't double-run.
+export async function settleExpedition(
+  expeditionId: unknown,
+  award: number,
+): Promise<boolean> {
+  const result = await ExpeditionModel.findOneAndUpdate(
+    { _id: expeditionId, settled: false },
+    { $set: { settled: true, cubeAwarded: award } },
+    { new: false },
+  )
+  return result !== null
+}
+
+// Settled-but-not-yet-credited rows, for crash-safe credit replay.
+export function findSettledUncredited(limit = 500) {
+  return ExpeditionModel.find({ settled: true, credited: false }).limit(limit)
+}
+
+// CAS: flip credited false->true. The winner is the one runner that should
+// call addPoints for this expedition.
+export async function claimCredit(expeditionId: unknown): Promise<boolean> {
+  const result = await ExpeditionModel.findOneAndUpdate(
+    { _id: expeditionId, credited: false },
+    { $set: { credited: true } },
+    { new: false },
+  )
+  return result !== null
+}

--- a/src/common/models/World.test.ts
+++ b/src/common/models/World.test.ts
@@ -1,0 +1,26 @@
+/* eslint-disable test/no-import-node-test */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { POOL_PER_WORLD, WORLD_DEFS, worldSeedDocs } from '#root/common/models/World'
+
+test('there are five worlds with stable ids', () => {
+  assert.equal(WORLD_DEFS.length, 5)
+  assert.deepEqual(
+    WORLD_DEFS.map((w) => w.worldId),
+    ['frostvault', 'emberwild', 'sunken-cube', 'verdant-maze', 'storm-spire'],
+  )
+})
+
+test('worldSeedDocs builds one pooled doc per world for a tick', () => {
+  const docs = worldSeedDocs(42)
+  assert.equal(docs.length, 5)
+  assert.deepEqual(docs[0], {
+    tickId: 42,
+    worldId: 'frostvault',
+    name: 'Frostvault',
+    cubePool: POOL_PER_WORLD,
+    totalWeight: 0,
+    explorerCount: 0,
+    settled: false,
+  })
+})

--- a/src/common/models/World.ts
+++ b/src/common/models/World.ts
@@ -1,0 +1,117 @@
+import { getModelForClass, modelOptions, prop } from '@typegoose/typegoose'
+import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+
+// Fixed CUBE pool per world per tick. This is the bounded faucet knob: total
+// CUBE minted per tick = POOL_PER_WORLD × number of non-empty worlds.
+export const POOL_PER_WORLD = 5000
+
+export interface WorldDef {
+  worldId: string
+  name: string
+}
+
+export const WORLD_DEFS: WorldDef[] = [
+  { worldId: 'frostvault', name: 'Frostvault' },
+  { worldId: 'emberwild', name: 'Emberwild' },
+  { worldId: 'sunken-cube', name: 'Sunken Cube' },
+  { worldId: 'verdant-maze', name: 'Verdant Maze' },
+  { worldId: 'storm-spire', name: 'Storm Spire' },
+]
+
+@modelOptions({ schemaOptions: { timestamps: true } })
+export class World extends TimeStamps {
+  @prop({ type: Number, required: true, index: true })
+  tickId!: number
+
+  @prop({ type: String, required: true })
+  worldId!: string
+
+  @prop({ type: String, required: true })
+  name!: string
+
+  @prop({ type: Number, required: true })
+  cubePool!: number
+
+  @prop({ type: Number, required: true, default: 0 })
+  totalWeight!: number
+
+  @prop({ type: Number, required: true, default: 0 })
+  explorerCount!: number
+
+  @prop({ type: Boolean, required: true, default: false, index: true })
+  settled!: boolean
+}
+
+const WorldModel = getModelForClass(World)
+
+// Compound unique index so a (tick, world) pair can only be seeded once and
+// concurrent seeders collide on E11000 rather than duplicating.
+WorldModel.collection.createIndex({ tickId: 1, worldId: 1 }, { unique: true }).catch(() => {})
+
+export { WorldModel }
+
+export interface WorldSeedDoc {
+  tickId: number
+  worldId: string
+  name: string
+  cubePool: number
+  totalWeight: number
+  explorerCount: number
+  settled: boolean
+}
+
+export function worldSeedDocs(tickId: number): WorldSeedDoc[] {
+  return WORLD_DEFS.map((def) => ({
+    tickId,
+    worldId: def.worldId,
+    name: def.name,
+    cubePool: POOL_PER_WORLD,
+    totalWeight: 0,
+    explorerCount: 0,
+    settled: false,
+  }))
+}
+
+// Idempotent: safe to call every tick / on startup. Uses an unordered bulk
+// upsert keyed on (tickId, worldId); already-seeded worlds are no-ops.
+export async function ensureWorldsForTick(tickId: number): Promise<void> {
+  const docs = worldSeedDocs(tickId)
+  await WorldModel.bulkWrite(
+    docs.map((doc) => ({
+      updateOne: {
+        filter: { tickId: doc.tickId, worldId: doc.worldId },
+        update: { $setOnInsert: doc },
+        upsert: true,
+      },
+    })),
+    { ordered: false },
+  )
+}
+
+export function findWorldsForTick(tickId: number) {
+  return WorldModel.find({ tickId }).sort({ worldId: 1 })
+}
+
+// Atomic crowd-counter bump when an expedition commits to a world.
+export async function addWorldCommitment(
+  tickId: number,
+  worldId: string,
+  weight: number,
+): Promise<void> {
+  await WorldModel.updateOne(
+    { tickId, worldId },
+    { $inc: { totalWeight: weight, explorerCount: 1 } },
+  )
+}
+
+// All unsettled worlds for closed ticks (tickId < currentTick), oldest first.
+export function findUnsettledWorlds(currentTickId: number) {
+  return WorldModel.find({ settled: false, tickId: { $lt: currentTickId } }).sort({
+    tickId: 1,
+    worldId: 1,
+  })
+}
+
+export async function markWorldSettled(tickId: number, worldId: string): Promise<void> {
+  await WorldModel.updateOne({ tickId, worldId }, { $set: { settled: true } })
+}

--- a/src/common/models/World.ts
+++ b/src/common/models/World.ts
@@ -1,4 +1,4 @@
-import { getModelForClass, modelOptions, prop } from '@typegoose/typegoose'
+import { getModelForClass, index, modelOptions, prop } from '@typegoose/typegoose'
 import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
 
 // Fixed CUBE pool per world per tick. This is the bounded faucet knob: total
@@ -18,6 +18,11 @@ export const WORLD_DEFS: WorldDef[] = [
   { worldId: 'storm-spire', name: 'Storm Spire' },
 ]
 
+// Compound unique index so a (tick, world) pair can only be seeded once and
+// concurrent seeders collide on E11000 rather than duplicating. Declared at
+// schema level so Mongoose surfaces creation errors through the normal boot
+// flow rather than swallowing them.
+@index({ tickId: 1, worldId: 1 }, { unique: true })
 @modelOptions({ schemaOptions: { timestamps: true } })
 export class World extends TimeStamps {
   @prop({ type: Number, required: true, index: true })
@@ -43,10 +48,6 @@ export class World extends TimeStamps {
 }
 
 const WorldModel = getModelForClass(World)
-
-// Compound unique index so a (tick, world) pair can only be seeded once and
-// concurrent seeders collide on E11000 rather than duplicating.
-WorldModel.collection.createIndex({ tickId: 1, worldId: 1 }, { unique: true }).catch(() => {})
 
 export { WorldModel }
 

--- a/src/frontend/components.d.ts
+++ b/src/frontend/components.d.ts
@@ -15,6 +15,7 @@ declare module 'vue' {
     ClaimComponent: typeof import('./src/components/ClaimComponent.vue')['default']
     ClickerComponent: typeof import('./src/components/ClickerComponent.vue')['default']
     CNFT: typeof import('./src/components/CNFT.vue')['default']
+    ExpeditionComponent: typeof import('./src/components/ExpeditionComponent.vue')['default']
     FAQ: typeof import('./src/components/FAQ.vue')['default']
     LeaderboardComponent: typeof import('./src/components/LeaderboardComponent.vue')['default']
     LoadingOverlay: typeof import('./src/components/nested/LoadingOverlay.vue')['default']

--- a/src/frontend/src/components/ExpeditionComponent.vue
+++ b/src/frontend/src/components/ExpeditionComponent.vue
@@ -169,12 +169,16 @@ onMounted(() => {
             class="toggle-btn"
             :class="{ active: risk === 'safe' }"
             @click="risk = 'safe'"
-          >Safe</button>
+          >
+            Safe
+          </button>
           <button
             class="toggle-btn"
             :class="{ active: risk === 'greedy' }"
             @click="risk = 'greedy'"
-          >Greedy</button>
+          >
+            Greedy
+          </button>
         </div>
 
         <!-- Expedition error -->

--- a/src/frontend/src/components/ExpeditionComponent.vue
+++ b/src/frontend/src/components/ExpeditionComponent.vue
@@ -1,0 +1,417 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useUserStore } from '../stores/userStore.js'
+
+interface World {
+  worldId: string
+  name: string
+  cubePool: number
+  explorerCount: number
+  totalWeight: number
+}
+
+interface MyExpedition {
+  worldId: string
+  risk: string
+  weight: number
+}
+
+interface WorldsResponse {
+  tickId: string
+  energy: { current: number; max: number }
+  worlds: World[]
+  myExpedition: MyExpedition | null
+  error?: string
+}
+
+interface ExpeditionResponse {
+  worldId: string
+  risk: string
+  weight: number
+  tickId: string
+  error?: string
+}
+
+interface EnergyRefillResponse {
+  energy: { current: number; max: number }
+  spent: number
+  error?: string
+}
+
+const userStore = useUserStore()
+
+const energy = ref<{ current: number; max: number } | null>(null)
+const worlds = ref<World[]>([])
+const myExpedition = ref<MyExpedition | null>(null)
+const risk = ref<'safe' | 'greedy'>('safe')
+const boardError = ref('')
+const expeditionError = ref('')
+const refillError = ref('')
+const isLoading = ref(false)
+const isSending = ref(false)
+const isRefilling = ref(false)
+
+async function fetchBoard() {
+  if (!userStore.initData) return
+  isLoading.value = true
+  boardError.value = ''
+  try {
+    const response = await fetch('/api/game/worlds', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData: userStore.initData }),
+    })
+    const data: WorldsResponse = await response.json()
+    if (data.error) {
+      boardError.value = data.error
+      return
+    }
+    energy.value = data.energy
+    worlds.value = data.worlds
+    myExpedition.value = data.myExpedition
+  } catch (err) {
+    boardError.value = 'Failed to load expedition board.'
+    console.error('Error fetching worlds:', err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function joinExpedition(worldId: string) {
+  if (!userStore.initData || myExpedition.value) return
+  isSending.value = true
+  expeditionError.value = ''
+  try {
+    const response = await fetch('/api/game/expedition', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData: userStore.initData, worldId, risk: risk.value }),
+    })
+    const data: ExpeditionResponse = await response.json()
+    if (data.error) {
+      expeditionError.value = data.error
+      return
+    }
+    await fetchBoard()
+  } catch (err) {
+    expeditionError.value = 'Failed to join expedition.'
+    console.error('Error joining expedition:', err)
+  } finally {
+    isSending.value = false
+  }
+}
+
+async function refillEnergy() {
+  if (!userStore.initData) return
+  isRefilling.value = true
+  refillError.value = ''
+  try {
+    const response = await fetch('/api/game/energy/refill', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData: userStore.initData }),
+    })
+    const data: EnergyRefillResponse = await response.json()
+    if (data.error) {
+      refillError.value = data.error
+      return
+    }
+    await fetchBoard()
+  } catch (err) {
+    refillError.value = 'Failed to refill energy.'
+    console.error('Error refilling energy:', err)
+  } finally {
+    isRefilling.value = false
+  }
+}
+
+onMounted(() => {
+  fetchBoard()
+})
+</script>
+
+<template>
+  <div class="expedition-container">
+    <h1 class="expedition-title">Expeditions</h1>
+
+    <div v-if="!userStore.initData" class="gate-card">
+      <p class="gate-title">Authorizing profile...</p>
+      <p class="gate-subtitle">Please wait before opening expedition data.</p>
+    </div>
+
+    <template v-else>
+      <div v-if="isLoading" class="info-text">Loading board...</div>
+      <div v-else-if="boardError" class="error-text">{{ boardError }}</div>
+
+      <template v-else>
+        <!-- Energy bar -->
+        <div v-if="energy" class="energy-card">
+          <div class="energy-label">Energy: {{ energy.current }} / {{ energy.max }}</div>
+          <div class="energy-bar">
+            <div
+              class="energy-fill"
+              :style="{ width: `${energy.max > 0 ? (energy.current / energy.max) * 100 : 0}%` }"
+            />
+          </div>
+        </div>
+
+        <!-- Active expedition notice -->
+        <div v-if="myExpedition" class="active-expedition">
+          <span class="active-label">Committed to world:</span>
+          <span class="active-value">{{ myExpedition.worldId }}</span>
+          <span class="active-risk">({{ myExpedition.risk }}, weight {{ myExpedition.weight }})</span>
+        </div>
+
+        <!-- Risk toggle -->
+        <div class="risk-toggle">
+          <span class="toggle-label">Risk:</span>
+          <button
+            class="toggle-btn"
+            :class="{ active: risk === 'safe' }"
+            @click="risk = 'safe'"
+          >Safe</button>
+          <button
+            class="toggle-btn"
+            :class="{ active: risk === 'greedy' }"
+            @click="risk = 'greedy'"
+          >Greedy</button>
+        </div>
+
+        <!-- Expedition error -->
+        <div v-if="expeditionError" class="error-text">{{ expeditionError }}</div>
+
+        <!-- World list -->
+        <div class="worlds-list">
+          <div v-for="world in worlds" :key="world.worldId" class="world-card">
+            <div class="world-name">{{ world.name }}</div>
+            <div class="world-stats">
+              <span class="stat">Pool: {{ world.cubePool.toLocaleString('en-US') }} ◆</span>
+              <span class="stat">Explorers: {{ world.explorerCount }}</span>
+            </div>
+            <button
+              class="main-button world-btn"
+              :disabled="!!myExpedition || isSending"
+              @click="joinExpedition(world.worldId)"
+            >
+              <span v-if="myExpedition?.worldId === world.worldId">Committed</span>
+              <span v-else>Join ({{ risk }})</span>
+            </button>
+          </div>
+        </div>
+
+        <div v-if="worlds.length === 0 && !isLoading" class="info-text">
+          No worlds available this tick.
+        </div>
+
+        <!-- Refill energy -->
+        <div class="refill-section">
+          <div v-if="refillError" class="error-text">{{ refillError }}</div>
+          <button
+            class="main-button refill-btn"
+            :disabled="isRefilling"
+            @click="refillEnergy"
+          >
+            <span v-if="isRefilling">Refilling...</span>
+            <span v-else>Refill energy (500 ◆)</span>
+          </button>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.expedition-container {
+  background-color: rgba(0, 0, 51, 0.7);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin: 1rem 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0 20px rgba(51, 102, 255, 0.2);
+  animation: fadeIn 1s;
+  backdrop-filter: blur(5px);
+}
+
+.expedition-title {
+  color: #fff;
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.5);
+}
+
+.gate-card {
+  padding: 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  text-align: center;
+}
+
+.gate-title {
+  margin: 0;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.gate-subtitle {
+  margin: 0.6rem 0 0;
+  color: #d2ddff;
+  font-size: 0.88rem;
+}
+
+.energy-card {
+  margin-bottom: 1.2rem;
+}
+
+.energy-label {
+  color: #ccccff;
+  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+  text-align: center;
+}
+
+.energy-bar {
+  height: 0.75rem;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+
+.energy-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #3366ff, #6633ff);
+  border-radius: 0.375rem;
+  transition: width 0.4s ease;
+}
+
+.active-expedition {
+  background: rgba(51, 204, 102, 0.12);
+  border: 1px solid rgba(51, 204, 102, 0.3);
+  border-radius: 0.75rem;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.active-label {
+  color: #99ffcc;
+  font-size: 0.88rem;
+  margin-right: 0.4rem;
+}
+
+.active-value {
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+  margin-right: 0.4rem;
+}
+
+.active-risk {
+  color: #aaddff;
+  font-size: 0.82rem;
+}
+
+.risk-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.toggle-label {
+  color: #ccccff;
+  font-size: 0.9rem;
+}
+
+.toggle-btn {
+  flex: 1;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+  color: #aaaacc;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.toggle-btn.active {
+  background: linear-gradient(90deg, #3366ff, #6633ff);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0 8px rgba(102, 51, 255, 0.4);
+}
+
+.worlds-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.world-card {
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.world-name {
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.world-stats {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.6rem;
+}
+
+.stat {
+  color: #ccccff;
+  font-size: 0.85rem;
+}
+
+.world-btn {
+  font-size: 0.9rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.refill-section {
+  margin-top: 1.25rem;
+}
+
+.refill-btn {
+  font-size: 0.95rem;
+}
+
+.info-text {
+  color: #ccccff;
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 0.75rem 0;
+}
+
+.error-text {
+  color: #ff6666;
+  font-size: 0.88rem;
+  text-align: center;
+  padding: 0.5rem 0;
+  margin-bottom: 0.5rem;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/src/frontend/src/routes.ts
+++ b/src/frontend/src/routes.ts
@@ -1,6 +1,7 @@
 import ClaimComponent from './components/ClaimComponent.vue'
 import ClickerComponent from './components/ClickerComponent.vue'
 import CNFTComponent from './components/CNFT.vue'
+import ExpeditionComponent from './components/ExpeditionComponent.vue'
 import FAQComponent from './components/FAQ.vue'
 import LeaderboardComponent from './components/LeaderboardComponent.vue'
 import NotFoundComponent from './components/NotFound.vue'
@@ -44,6 +45,13 @@ export const menuRoutes: MenuRoute[] = [
     emoji: '⛏️',
     showInMenu: true,
     component: SatoshiMiningComponent,
+  },
+  {
+    path: '/expeditions',
+    name: 'ExpeditionsPage',
+    emoji: '⚔️',
+    showInMenu: true,
+    component: ExpeditionComponent,
   },
   {
     path: '/cnft',

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,13 @@
 import process from 'node:process'
 import mongoose from 'mongoose'
 import { onShutdown } from 'node-graceful-shutdown'
+import settlementRunner from '#root/backend/expedition-settlement'
 import { setMenuButton, syncBotCommands } from '#root/bot/handlers/commands/sync-commands'
 import { createBot } from '#root/bot/index'
+import { currentTickId } from '#root/common/helpers/tick'
 import { ensureClaimUniquenessMigration } from '#root/common/models/Claim'
 import { createInitialBalancesIfNotExists } from '#root/common/models/User'
+import { ensureWorldsForTick } from '#root/common/models/World'
 import { config } from '#root/config'
 import { logger } from '#root/logger'
 import { createServer } from '#root/server'
@@ -49,6 +52,23 @@ try {
   const subscription = new Subscription(bot)
 
   void subscription.startProcessTransactions()
+
+  // Seed the current tick's worlds so the board is never empty, then run
+  // settlement every minute. Each run closes any tick that has rolled over
+  // and is idempotent, so overlapping intervals or restarts are safe.
+  await ensureWorldsForTick(currentTickId())
+  const SETTLEMENT_INTERVAL_MS = 60 * 1000
+  const settlementTimer = setInterval(() => {
+    void (async () => {
+      try {
+        await ensureWorldsForTick(currentTickId())
+        await settlementRunner.runOnce()
+      } catch (error) {
+        logger.error(error)
+      }
+    })()
+  }, SETTLEMENT_INTERVAL_MS)
+  settlementTimer.unref()
 
   if (config.BOT_MODE === 'webhook') {
     // to prevent receiving updates before the bot is ready

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { logger, loggerOptions } from '#root/logger'
 import authHandler from './backend/auth-handler'
 import balancesHandler from './backend/balances-handler'
 import claimHandler from './backend/claim-handler'
+import expeditionHandler from './backend/expedition-handler'
 import leaderboardHandler from './backend/leaderboard-handler'
 import nftHandler from './backend/nft-handler'
 import setWalletHandler from './backend/set-wallet-handler'
@@ -30,6 +31,7 @@ const ROUTE_RATE_LIMITS: Record<string, { max: number, timeWindow: string }> = {
   '/api/users/leaderboard': { max: 60, timeWindow: '1 minute' },
   '/api/users/balances': { max: 60, timeWindow: '1 minute' },
   '/api/game/worlds': { max: 60, timeWindow: '1 minute' },
+  '/api/game/expedition': { max: 30, timeWindow: '1 minute' },
 }
 
 export async function createServer(bot: Bot) {
@@ -107,6 +109,7 @@ export async function createServer(bot: Bot) {
   await server.register(claimHandler, { prefix: '/api/users' })
 
   await server.register(worldsHandler, { prefix: '/api/game' })
+  await server.register(expeditionHandler, { prefix: '/api/game' })
 
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { logger, loggerOptions } from '#root/logger'
 import authHandler from './backend/auth-handler'
 import balancesHandler from './backend/balances-handler'
 import claimHandler from './backend/claim-handler'
+import energyHandler from './backend/energy-handler'
 import expeditionHandler from './backend/expedition-handler'
 import leaderboardHandler from './backend/leaderboard-handler'
 import nftHandler from './backend/nft-handler'
@@ -32,6 +33,7 @@ const ROUTE_RATE_LIMITS: Record<string, { max: number, timeWindow: string }> = {
   '/api/users/balances': { max: 60, timeWindow: '1 minute' },
   '/api/game/worlds': { max: 60, timeWindow: '1 minute' },
   '/api/game/expedition': { max: 30, timeWindow: '1 minute' },
+  '/api/game/energy/refill': { max: 20, timeWindow: '1 minute' },
 }
 
 export async function createServer(bot: Bot) {
@@ -110,6 +112,7 @@ export async function createServer(bot: Bot) {
 
   await server.register(worldsHandler, { prefix: '/api/game' })
   await server.register(expeditionHandler, { prefix: '/api/game' })
+  await server.register(energyHandler, { prefix: '/api/game' })
 
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import leaderboardHandler from './backend/leaderboard-handler'
 import nftHandler from './backend/nft-handler'
 import setWalletHandler from './backend/set-wallet-handler'
 import walletNonceHandler from './backend/wallet-nonce-handler'
+import worldsHandler from './backend/worlds-handler'
 import { config } from './config'
 
 const ROUTE_RATE_LIMITS: Record<string, { max: number, timeWindow: string }> = {
@@ -28,6 +29,7 @@ const ROUTE_RATE_LIMITS: Record<string, { max: number, timeWindow: string }> = {
   '/api/users/claim/status': { max: 30, timeWindow: '1 minute' },
   '/api/users/leaderboard': { max: 60, timeWindow: '1 minute' },
   '/api/users/balances': { max: 60, timeWindow: '1 minute' },
+  '/api/game/worlds': { max: 60, timeWindow: '1 minute' },
 }
 
 export async function createServer(bot: Bot) {
@@ -103,6 +105,8 @@ export async function createServer(bot: Bot) {
   await server.register(balancesHandler, { prefix: '/api/users' })
   await server.register(leaderboardHandler, { prefix: '/api/users' })
   await server.register(claimHandler, { prefix: '/api/users' })
+
+  await server.register(worldsHandler, { prefix: '/api/game' })
 
   const __filename = fileURLToPath(import.meta.url)
   const __dirname = path.dirname(__filename)


### PR DESCRIPTION
## Summary

Implements the **playable, fully-tested core loop** of the Cube Worlds expedition economy (Plan 1 of a 3-plan series). Spend Energy to send an expedition to one of 5 cube-worlds per 1-hour tick; at tick close, each world's fixed CUBE pool is split among its explorers by *effective weight* (crowd-dilution congestion game). Two of the three CUBE sinks ship here, alongside the bounded faucet.

Soft-currency only — no real-money code. Per the economy invariant ("three CUBE sinks before the faucet ships"), the expedition faucet stays gated for **production** until the third sink (tournament entry) lands in Plan 3. This is a release-config decision, not a code dependency; the branch is independently testable and mergeable.

## What's included

**Pure math helpers (100% line/branch/function coverage):**
- `tick.ts` — 1-hour tick id math (no tick table; derived from the clock)
- `energy.ts` — lazy energy regen + loop constants
- `congestion.ts` — the bounded pool-split formula (`weight × riskMultiplier`, `FLOOR_PAYOUT` guarantee)

**Models (mirror the `Claim` atomic CAS + idempotent-startup pattern):**
- `Energy` — per-user, atomic compare-and-swap spend
- `World` — per-`(tickId, worldId)` pool + crowd counters, idempotent seeding
- `Expedition` — one commitment per `(userId, tickId)`, two-flag (`settled` → `credited`) crash-safe settlement

**Handlers (DI `build*Handler(deps)` pattern):**
- `POST /api/game/worlds` — board + my energy + my commitment
- `POST /api/game/expedition` — send (energy spend + optional CUBE weight-boost sink)
- `POST /api/game/energy/refill` — CUBE→Energy sink

**Worker:** `buildSettlementRunner(deps)` — idempotently closes past ticks and credits CUBE via `addPoints` (started on an interval in `main.ts`).

**Ledger:** added `Expedition` (faucet) and `Spend` (sink) `BalanceChangeType`s.

**Frontend:** minimal `ExpeditionComponent.vue` board.

## Known MVP trade-offs (documented in-code)
- Energy is spent before the duplicate-tick commitment is rejected (only reachable by a user racing themselves).
- Credit-flag-then-`addPoints` has a narrow crash window; Plan 2's reconciliation worker is the mitigation.

## Verification
- ✅ `npm run test:backend` — 477/477 passing
- ✅ `npm run lint` — 0 errors / 0 warnings
- ✅ `npm run typecheck` — clean
- ✅ Coverage: `tick.ts`, `energy.ts`, `congestion.ts` all at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)