### PR TITLE
ci: dedupe push + PR double runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Main
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Dedupe CI runs on PRs

The `Main` workflow triggered on both bare `push:` and `pull_request:`, so every PR commit ran `quality` + `backend-tests` **twice** — once for the branch push, once for the PR event.

Scoping the `push` trigger to `main` keeps:
- **feature branches** → checked once, via the `pull_request` event;
- **`main`** → still checked on every push (i.e. on merge).

No behavioral change to what gets validated — only removes the redundant duplicate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
