### PR TITLE
docs: refresh agent instructions + design docs for DB-only pivot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,66 +2,79 @@
 
 ## Project Summary
 
-Cube Worlds is a Telegram Mini App game on the TON blockchain. Users earn CUBE points via daily claims and referrals; admins curate the queue of users whose AI-generated NFTs get minted. The app also supports CUBE-to-SATOSHI token exchange and an idle clicker.
+Cube Worlds is a Telegram Mini App game on the TON blockchain. **$CUBE is a DB-only
+soft currency** (no on-chain jetton): players earn `votes` from daily claims, referrals,
+and **TON donations**, which rank a queue for **on-chain NFT minting** via a webview
+semi-automatic flow. Owning the NFT gates game entry. On top of that sits an
+ancient-world ARPG/4X economy — castles, heroes, expeditions, PvP arena/raids, weekly
+tournaments — plus a real-money (USDT) rail through xRocket.
 
-Three parts: Telegram bot (Grammy), Fastify API backend, Vue 3 frontend (Vite). MongoDB via Typegoose.
+Three parts: Telegram bot (Grammy), Fastify API backend, Vue 3 frontend (Vite).
+MongoDB via Typegoose. ESM only, no semicolons, single quotes, 2-space indent.
 
-The dice game and ChatGPT-powered story game (`/dice`, `/mint`, `/play`) were removed; the captcha endpoint and `suspicionDices` field remain as orphaned scaffolding from those flows.
+> **Source of truth:** `CLAUDE.md` carries the detailed, continuously-updated context
+> (feature-by-feature). This file is the generic-agent orientation; `ARCHITECTURE.md`
+> has the system diagram. When they disagree, trust `CLAUDE.md`.
 
-See `CLAUDE.md` for the compact context summary and `ARCHITECTURE.md` for the system diagram.
+### Recent pivot (2026-06-14)
+
+The on-chain $CUBE jetton bridge **and** the CUBE→SATOSHI jetton exchange were removed.
+$CUBE is now DB-only (`User.votes` + the `Balance` ledger are canonical). The old
+admin-curated, per-step NFT queue was replaced by a binary **Approve / Return** admin
+action plus a player-facing **webview mint** (`/api/mint`). The dice/story games
+(`/dice`, `/mint`, `/play`) and the captcha endpoint were already gone. Do not
+reintroduce any of these — the `removedCommandsFeature` safety net points users at the
+Mini App for the old commands.
 
 ## Repository Layout
 
 ```
-src/main.ts              — Entrypoint: MongoDB → bot → server → subscription → start
-src/server.ts            — Fastify: registers all handlers under /api/ prefixes
-src/config.ts            — Env config (znv/zod, lazy proxy singleton)
-src/subscription.ts      — TON blockchain transaction poller (composer wiring)
-src/subscription-start.ts — Pure builder for the subscription startup logic (DI)
-src/subscription-core.ts — Top-level subscription wiring
+src/main.ts               — Entrypoint: MongoDB → bot → server → subscription → workers
+src/server.ts             — Fastify: registers all handlers under /api/ prefixes
+src/config.ts             — Env config (znv/zod, lazy proxy; THROWS on read in NODE_ENV=test)
+src/subscription-core.ts  — TON transaction watcher (donations → votes faucet)
+src/subscription.ts       — Composer wiring for the watcher
 src/bot/
-  index.ts               — Middleware chain + feature registration (ORDER MATTERS)
-  context.ts             — Grammy Context + SessionData type definitions
-  callback-data/*.ts     — Typed callback-data packers (e.g. image-selection)
+  index.ts                — Middleware chain + feature registration (ORDER MATTERS)
+  context.ts              — Grammy Context + SessionData types
   features/
-    start.ts             — /start (referral capture, wallet prompt)
-    help.ts              — /help (split into help-handler.ts + help.ts)
-    line.ts              — /line — leaderboard preview in chat
-    stats.ts             — /stats (split)
-    whales.ts            — /whales — top-vote ranking
-    removed-commands.ts  — Catches /dice /mint /play and points to the Mini App (split)
-    unhandled.ts         — Final fallback (split)
+    start.ts              — /start (referral capture, wallet prompt)
+    help.ts               — /help        (split: help-handler.ts + help.ts)
+    line.ts               — /line — leaderboard preview in chat
+    stats.ts              — /stats        (split)
+    whales.ts             — /whales — top-vote ranking
+    season-pass.ts        — Telegram Stars pre_checkout + successful_payment  (split)
+    removed-commands.ts   — Catches /dice /mint /play → points to the Mini App (split)
+    unhandled.ts          — Final fallback
     admin/
-      queue.ts           — /queue — admin NFT mint workflow
-      collection.ts      — /collection — admin browse minted CNFTs
-      parameters.ts      — /params — runtime tweaks
-      transaction.ts     — /tx — admin transaction inspection (split)
-      user.ts            — /user — admin user inspection (split)
-  filters/is-admin.ts    — Auth filter for admin-only commands
-  handlers/              — Error boundary + sync-commands runner
-  middlewares/
-    attach-user.ts       — Loads/creates User from DB
-    reaction.ts          — slapReaction (auto-react to messages)
-    update-logger.ts     — Dev-only update logging
-  keyboards/             — Inline keyboards (photo, queue-menu)
-src/backend/
-  auth-handler.ts        — POST /api/auth/login (initData validation)
-  set-wallet-handler.ts  — POST /api/auth/set-wallet (TON address)
-  claim-handler.ts       — POST /api/users/claim + /claim/status (daily rewards)
-  leaderboard-handler.ts — GET /api/users/leaderboard (paginated, bounded)
-  balances-handler.ts    — GET /api/users/balances (aggregate stats)
-  nft-handler.ts         — NFT metadata + image generation (input-validated)
-  captcha.ts             — HMAC-signed captcha verification (no longer invoked by any feature; vestigial)
-  *.test.ts              — Tests (Node.js test runner, DI-based mocking)
+      queue.ts            — /queue — NFT mint approve/return  (split: queue-approval-handler.ts)
+      collection.ts       — /collection — browse minted CNFTs
+      parameters.ts       — /params — runtime tweaks
+      transaction.ts      — /tx          (split)
+      user.ts             — /user        (split)
+  filters/is-admin.ts     — Auth filter for admin-only commands (reads config — composer only)
+src/backend/              — Fastify route handlers, all DI-split (see Key Patterns)
+  auth-handler.ts         — POST /api/auth/login (initData validation, upsert, minted/mintState)
+  set-wallet-handler.ts + wallet-nonce-handler.ts + ton-proof.ts — TON Connect ton_proof binding
+  mint-handler.ts + mint.ts            — POST /api/mint/{quote,generate,status} (webview mint)
+  claim-handler.ts        — daily claim
+  production-handler.ts, castle-upgrade-handler.ts          — Castle / resources
+  hero-handler.ts, dungeon-handler.ts, quest-handler.ts     — Heroes / PvE
+  equipment-handler.ts, boss-handler.ts                     — Equipment / boss week
+  pvp-handler.ts, pvp-matchmaking.ts                        — Arena + raids
+  expedition-handler.ts, worlds-handler.ts, energy-handler.ts — Expedition economy
+  tournament-handler.ts, ad-reward-handler.ts, season-pass-invoice-handler.ts — Monetization
+  wallet-handler.ts, wallet-webhook-handler.ts, xrocket-client.ts — xRocket USDT money rail
+  *-settlement.ts + *-settlement-runner.ts — Idempotent background workers
+  *-mint.ts + *-mint-runner.ts + *-nft-client.ts — Deploy-gated on-chain NFT mints
 src/common/
-  models/                — User, Balance, Claim, CNFT, Transaction, Vote
-  helpers/               — ton, ipfs, generation, files, telegram, random, satoshi, etc.
-  i18n.ts                — Fluent i18n middleware
-src/frontend/            — Vue 3 app (separate package.json)
-  src/routes.ts          — Frontend route table (some entries have showInMenu: false)
-  src/components/        — Page-level components (ClaimComponent, FAQ, CNFT, etc.)
-  src/stores/userStore.ts — Pinia store (wallet, user, balance, initData)
-  captcha/               — Standalone DOOM captcha (HTML/JS, NOT Vue, currently unused)
+  models/                 — Typegoose models (User, Balance, CNFT, Castle, Hero, Match, ...)
+  helpers/                — Pure helpers (mint-floor, combat, dungeon, production, tournament, ...)
+  i18n.ts                 — Fluent i18n middleware
+src/frontend/             — Vue 3 app (separate package.json — keep deps isolated)
+  src/routes.ts           — Route table; router.beforeEach locks non-minted users to /mint
+  src/components/         — Page components (Castle, HeroRoster, Arena, Mint, Wallet, ...)
+  src/stores/userStore.ts — Pinia store (wallet, user, balance, initData, minted/mintState)
 ```
 
 ## Key Patterns
@@ -75,37 +88,44 @@ export function buildFooHandler(deps = createDefaultDependencies()) {
   return async function(ctx) { /* ... */ }
 }
 ```
-Tests call `buildFooHandler({ findUser: mockFn })` to inject stubs. Follow this pattern for any new route or command.
+Tests call `buildFooHandler({ findUser: mockFn })` to inject stubs. Follow this for any
+new route or command. Reference: `auth-handler.test.ts` (route), `help-handler.test.ts` (command).
 
 ### Handler-split for config-touching modules
-`src/config.ts` is a lazy proxy that throws when `NODE_ENV=test` (because the schema's `NODE_ENV` enum doesn't include `test`). Any module imported transitively from a test must therefore not touch `config.X` at module load.
+`src/config.ts` is a lazy Proxy that **throws on any property read when `NODE_ENV=test`**.
+Any module a test imports — even transitively — must not touch `config.X` at load time.
+When a handler needs `isAdmin`, `tonClient`, or any config-derived dependency, split it:
+- `foo-handler.ts` — pure DI handler, no `config` / `is-admin` / `ton` / `xrocket` import
+- `foo.ts` — composer that imports the heavy deps and injects them
 
-When a command needs `isAdmin` (which reads `config.BOT_ADMINS` at load) or `tonClient` (which reads many config values), split the file:
-- `foo-handler.ts` — pure DI handler, no `config` / `is-admin` / `ton` imports
-- `foo.ts` — Composer wiring that imports `isAdmin` and passes it in via `createXyzHandlerDependencies(isAdmin)`
-
-See `balance-handler.ts` + `balance.ts` and `transaction-handler.ts` + `admin/transaction.ts` for reference splits.
+Reference splits: `mint-handler.ts` + `mint.ts`, `admin/transaction-handler.ts` +
+`admin/transaction.ts`, `wallet-handler.ts` + `wallet.ts`.
 
 ### Authentication
-Endpoints validate Telegram `initData` with BOT_TOKEN (24-hour expiry). Flow: client sends initData in body → server validates signature → extracts user ID → finds User in MongoDB.
+Endpoints validate Telegram `initData` (HMAC + 24h expiry) → extract `user.id` → look up
+in MongoDB. Wallet binding additionally requires TON Connect **ton_proof**: a stateless
+HMAC nonce (`/api/auth/wallet-nonce`) is signed by the wallet and verified in
+`ton-proof.ts` (payload HMAC + expiry + userId + domain + stateInit hash + Ed25519 sig).
 
-### Captcha Flow (vestigial)
-The HMAC-signed DOOM captcha is still wired end-to-end — `generateCaptchaToken()` in `src/backend/captcha.ts` mints tokens, `captcha/script.js` + `captcha.html` render the iframe, and `GET /api/captcha/check` verifies (`server.ts:29`). It was driven by the removed dice command, so nothing currently issues tokens or sets `User.suspicionDices`. Tests (`captcha.test.ts`) still exercise the token round-trip. Keep the auth invariants if you reuse it: no secrets client-side, BOT_TOKEN as HMAC key.
-
-### Game Currency
-`User.votes` (bigint) is the central CUBE balance. Modified via `addPoints()` which atomically increments with `$inc` and logs to Balance model. All changes tracked with `BalanceChangeType` enum.
+### Game currency & economy
+`User.votes` (bigint) is the canonical **DB-only** $CUBE balance, mutated only via
+`addPoints()` (`$inc` + a `Balance` ledger row tagged with `BalanceChangeType`). The
+separate **USDT money rail** stores `WalletBalance` in bigint micro-USDT and never mixes
+with the CUBE ledger. **Invariant: sinks ship before faucets** — the expedition CUBE
+faucet stays gated behind `EXPEDITION_FAUCET_ENABLED` (default off) until its sinks are
+tuned. See `docs/ECONOMY.md`.
 
 ## Common Commands
 
 ```bash
 npm install && npm --prefix src/frontend install   # Install all deps
-npm run dev                                         # Full app at :3000 — API + bot + frontend HMR (embedded vite)
+npm run dev                                         # Full app at :3000 — API + bot + frontend HMR
 npm --prefix src/frontend run dev                   # Optional: frontend-only vite (:5173, no /api)
 npm run build:all                                   # Build backend (tsc) + frontend (vite)
-npm run lint                                        # ESLint (@antfu/eslint-config)
+npm run lint                                        # ESLint
 npm run format                                      # Prettier
 npm run typecheck                                   # TypeScript (tsc)
-npm run test:backend                                # 455 tests (~6s)
+npm run test:backend                                # Full backend suite (Node.js test runner)
 npm run test:coverage                               # Per-file line/branch/func coverage
 ```
 
@@ -117,35 +137,41 @@ NODE_ENV=test node --import tsx --test src/backend/auth-handler.test.ts
 ## Agent Safety Rules
 
 - **ESM only** — `"type": "module"`. No `require()`.
-- **Import order** enforced — type imports first, then builtins, external, internal (`perfectionist/sort-imports`).
+- **Import order** enforced — type imports first; value imports external-before-internal
+  (`#root/*`) per `perfectionist/sort-imports`.
 - **Never touch `build/`** — generated output.
 - **Frontend isolation** — `src/frontend/` has its own `package.json`. Don't mix deps.
-- **One vite copy per process** — root and `src/frontend` both install vite; loading both copies of rolldown's native binding in one process segfaults. Dev mode dynamically imports vite from `src/frontend/node_modules` in `server.ts` — never add a top-level `import 'vite'` to backend code.
-- **Browser Buffer** — `@ton/core` needs a global `Buffer` in the browser; `src/frontend/src/polyfills.ts` (first module entry in `index.html`) provides it. Vite 8 ignores `optimizeDeps.esbuildOptions` — don't re-add esbuild-era polyfill plugins.
-- **File paths** — always use `folderPath()` from `src/common/helpers/files.ts` for user-data directories. It sanitizes names and checks path boundaries.
-- **Secrets** — BOT_TOKEN, MNEMONICS, API keys come from `.env`. Never log them. Never hardcode cryptographic keys client-side.
-- **NFT image params** — `image` must be validated against CNFTImageType whitelist, `color` as integer 0-10, `index` as non-negative integer.
-- **Pagination** — leaderboard limit is capped at 100. Apply similar bounds to any new paginated endpoint.
-- **`NODE_ENV=test` gotcha** — see the handler-split note above. Tests must not transitively load `#root/config`.
+- **One vite copy per process** — root and `src/frontend` both install vite; loading both
+  copies of rolldown's native binding in one process segfaults on dlopen. Dev mode
+  dynamically imports vite from `src/frontend/node_modules` in `server.ts` — never add a
+  top-level `import 'vite'` to backend code.
+- **Browser Buffer** — `@ton/core` needs a global `Buffer`; `src/frontend/src/polyfills.ts`
+  (first module in `index.html`) provides it. Vite 8 ignores `optimizeDeps.esbuildOptions`.
+- **File paths** — use `folderPath()` from `src/common/helpers/files.ts` for any user-data
+  path; it sanitizes names and checks the `./data/` boundary.
+- **Secrets** — BOT_TOKEN, MNEMONICS, xRocket/Stability/OpenAI keys come from `.env`.
+  Never log them. Never hardcode cryptographic keys client-side.
+- **Pagination** — leaderboard limit capped 1–100, skip ≥ 0. Bound any new paginated endpoint.
+- **Idempotency** — settlement workers, the wallet webhook, and NFT mints are
+  exactly-once via unique `externalId` / status-CAS. Preserve this when editing them.
+- **`NODE_ENV=test` gotcha** — see the handler-split note. Tests must not transitively
+  load `#root/config`.
 
 ## Testing
 
-- **Runner:** Node.js built-in (`node --test`)
+- **Runner:** Node.js built-in (`node --test`) — not Jest/Vitest.
 - **Command:** `npm run test:backend`
-- **Current state:** 422 tests across 53 files
-- **Pattern:** Use DI to inject mock dependencies. See `auth-handler.test.ts` for reference.
+- **Pattern:** DI mock injection. See `auth-handler.test.ts` for reference.
 - **Before finishing any change:**
   ```bash
-  npm run lint && npm run typecheck && npm run test:backend && npm --prefix src/frontend run build
+  npm run lint && npm run typecheck && npm run test:backend && npm run build:all
   ```
-
-## Known TODOs
-
-- `src/bot/features/admin/queue.ts:244` — Re-enable `sendNewPlaces` notification (currently commented out along with the import on line 35)
 
 ## Further Reading
 
-- `CLAUDE.md` — Compact project context
+- `CLAUDE.md` — Detailed, current project context (feature-by-feature)
 - `ARCHITECTURE.md` — System shape overview
 - `CODEX.md` — Quick reference for Codex / Cursor
-- `docs/FUTURE_DEVELOPMENT.md` — Prioritized improvements and feature ideas
+- `docs/ECONOMY.md` — Tokenomics, sink discipline, financial model
+- `docs/ANCIENT_WORLDS_PLAN.md` — Game design & roadmap
+- `docs/FUTURE_DEVELOPMENT.md` — Prioritized improvements

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,17 +15,22 @@
                         │  src/common/     │
                         └────────┬─────────┘
                                  │
-                        ┌────────┴─────────┐
-                        │  TON Blockchain  │
-                        │  (subscription)  │
-                        └──────────────────┘
+              ┌──────────────────┼──────────────────┐
+              │                  │                  │
+     ┌────────┴────────┐ ┌───────┴────────┐ ┌───────┴────────┐
+     │  TON Blockchain │ │   xRocket      │ │  Telegram      │
+     │  (donations,    │ │  (USDT money   │ │  Stars         │
+     │   NFT minting)  │ │   rail)        │ │  (Season Pass) │
+     └─────────────────┘ └────────────────┘ └────────────────┘
 ```
 
 - **Telegram bot** runs on Node.js (TypeScript, ESM) using Grammy for updates.
 - **HTTP server** is Fastify with `@fastify/middie` (for Vite middleware in dev mode).
 - **Data** is stored in MongoDB via Mongoose/Typegoose with decorator-based schemas.
 - **Frontend** is a Vue 3 + Vite app under `src/frontend` (separate `package.json`).
-- **Captcha** is a standalone DOOM-style HTML/JS game under `src/frontend/captcha/` (not Vue). The HMAC-verification endpoint at `/api/captcha/check` is still mounted, but no bot feature currently issues captcha tokens — it is vestigial scaffolding left over from the removed dice command.
+- **Two value layers, kept separate:** $CUBE is a **DB-only** soft currency (`User.votes`
+  + the `Balance` ledger); the **USDT money rail** (xRocket) stores `WalletBalance` in
+  bigint micro-USDT and never mixes with the CUBE ledger.
 
 ## Startup Flow
 
@@ -35,64 +40,107 @@
 3. Initialize default balance records if empty
 4. Create Fastify HTTP server (register all API handlers)
 5. Register shutdown handlers (SIGINT/SIGTERM)
-6. Start TON transaction subscription service
-7. Start bot (polling mode in dev, webhook in prod)
+6. Start the TON transaction watcher (donations → votes)
+7. Start background workers: expedition / tournament / boss settlement (idempotent),
+   wallet reconciliation, and the deploy-gated NFT mint runners (mint / castle / hero /
+   equipment) — each gated by its config flag or `*_COLLECTION_ADDRESS`
+8. Start bot (polling mode in dev, webhook in prod)
 
 ## Key Runtime Flows
 
-### User Onboarding
-`/start` command → `findOrCreateUser()` → referral check → prompt to set wallet
+### User Onboarding & Entry Gate
+`/start` → `findOrCreateUser()` → referral capture → wallet prompt. In the Mini App,
+`POST /api/auth/login` upserts the user and returns `minted` + `mintState`;
+`router.beforeEach` locks **non-minted** users to `/mint` and `MainMenu` hides game tabs
+until they own the NFT.
 
-### Daily Claim
-Frontend POST `/api/users/claim` → validate initData → per-user lock → find/create Claim → calculate streak multiplier → `addPoints()` → return new balance
+### Wallet Binding (TON Connect ton_proof)
+`POST /api/auth/wallet-nonce` issues a stateless HMAC nonce (5-min TTL, bound to userId)
+→ the wallet signs it → `POST /api/auth/set-wallet` verifies the proof in `ton-proof.ts`
+(payload HMAC + expiry + userId + domain + stateInit-hash + Ed25519 signature).
 
-### NFT Minting (Admin)
-`/queue` → admin selects user from ranked queue → choose/upload image → Stability AI generation → ChatGPT description → Pinata IPFS upload → on-chain TON NFT mint → mark user as minted
+### NFT Minting (webview semi-auto, admin-gated)
+Player flow (`/api/mint`): `quote` (floor / your votes / queue position) → `generate`
+(Stability pixel-art + ChatGPT description → draft, state `Submited`) → `status`. Admin
+flow: bot `/queue` shows ✅ **Approve** / ↩️ **Return-to-work**; approval re-checks the
+escalating floor server-side, CAS-claims the user (`claimUserForMint`), pins to IPFS, and
+deploys the NFT (mint-before-flip). The escalating floor (`mint-floor.ts`) raises the
+vote threshold as more NFTs mint. Owning the NFT gates game entry.
 
-### Removed Slash Commands
-The dice (`/dice`), NFT-mint (`/mint`), and story (`/play`) commands were removed. `removed-commands.ts` is the last `message:text` handler before `unhandledFeature` and replies to any leftover slash command with a Mini App link.
+### Daily Claim & Game Loop
+`POST /api/users/claim` → validate initData → per-user lock → streak multiplier →
+`addPoints()`. The ancient-worlds loop runs under `/api/game/*`: castle production &
+upgrades, hero recruitment / daily dungeon / 8h quest, weekly boss, PvP arena & raids,
+and the expedition economy (spend Energy → send to a cube-world → hourly settlement).
+
+### Money Rail (xRocket USDT)
+Deposits arrive via the signed `POST /api/wallet/webhook`; debits go through an atomic
+`{balance: $gte amount}` CAS; the `WalletLedger` is idempotent on `externalId`. An hourly
+reconciliation worker compares the ledger against xRocket custody and flips `WalletGuard`
+to pause withdrawals on divergence.
 
 ### Transaction Monitoring
-`src/subscription.ts` → polls TON blockchain → detects incoming payments → matches wallet to user → credits points (donation) or processes SATOSHI exchange
+`src/subscription-core.ts` polls TON for incoming payments, matches the **bound** wallet
+to a user, and credits `votes` as a `Donation`. (The former SATOSHI-exchange branch and
+the on-chain $CUBE bridge were removed.)
+
+### Removed Slash Commands
+The dice (`/dice`), NFT-mint (`/mint`), and story (`/play`) commands were removed.
+`removed-commands.ts` is the last `message:text` handler before `unhandledFeature` and
+replies to any leftover slash command with a Mini App link.
 
 ## Configuration
 
 - `.env` is required for runtime secrets and service endpoints.
 - Core config lives in `src/config.ts` using `znv` with Zod schemas.
 - Config uses a lazy proxy singleton — first property access triggers initialization.
-- In test mode (`NODE_ENV=test`), logger is silent and config uses fake values.
+- In test mode (`NODE_ENV=test`), the logger is silent and the config Proxy **throws on
+  any property read** — modules a test imports must not touch `config.X` at load time
+  (hence the pure-handler + composer split pattern).
 
 ## Integration Points
 
 - **Telegram Bot API** via Grammy (polling or webhook).
-- **TON blockchain** via @ton/ton for wallet operations, transaction monitoring, NFT minting.
-- **TonConnect** for wallet connection in the frontend.
+- **TON blockchain** via @ton/ton for wallet operations, donation monitoring, NFT minting.
+- **TonConnect** for wallet connection + ton_proof binding in the frontend.
+- **xRocket** for the USDT money rail (deposits, withdrawals, transfers, tournament payouts).
+- **Telegram Stars** for Season Pass purchases (`XTR`, subscription invoices).
+- **Adsgram** for rewarded ads (S2S reward callback verified by single-use HMAC nonce).
 - **Pinata** for IPFS storage of NFT metadata and images.
-- **Stability AI** for image-to-image generation (pixel-art style NFT artwork).
-- **OpenAI** for ChatGPT-powered NFT description generation in the admin mint flow.
-- **Telemetree** for analytics (config present but integration minimal).
+- **Stability AI** for image-to-image generation (pixel-art NFT artwork).
+- **OpenAI** for ChatGPT-powered NFT description generation.
 
 ## Build and Deployment
 
-- **Dev:** `npm run dev` (tsx watch) serves the full app at :3000 — vite runs as Fastify middleware with HMR, dynamically imported from `src/frontend/node_modules` (two copies of rolldown's native binding in one process segfault). `npm --prefix src/frontend run dev` is an optional frontend-only server (:5173, no /api).
+- **Dev:** `npm run dev` (tsx watch) serves the full app at :3000 — vite runs as Fastify
+  middleware with HMR, dynamically imported from `src/frontend/node_modules` (two copies
+  of rolldown's native binding in one process segfault). `npm --prefix src/frontend run
+  dev` is an optional frontend-only server (:5173, no /api).
 - **Build:** `npm run build:all` → tsc for backend, vite for frontend
-- **Production:** Docker (Node 20 slim), runs on port 80, nginx reverse proxy
+- **Production:** Docker (Node 20 slim) behind an nginx reverse proxy; Kamal scaffold under `.kamal/`
 - **Dev server:** Fastify serves Vite as middleware via `@fastify/middie`
-- **Prod server:** Fastify serves built frontend as static files via `@fastify/static`
+- **Prod server:** Fastify serves the built frontend as static files via `@fastify/static`
 
 ## Security Architecture
 
-- **Auth:** All authenticated endpoints validate Telegram `initData` signatures (24-hour expiry).
-- **Captcha (vestigial):** HMAC-SHA256 tokens signed with BOT_TOKEN. Generation/verification helpers in `src/backend/captcha.ts` still mount under `/api/captcha`, but no live caller issues tokens after the dice command was removed. Keep the invariant if you reuse it: no client-side secrets.
-- **Input validation:** NFT image types whitelisted, colors bounded (0-10), indexes validated as non-negative integers, addresses wrapped in try-catch.
-- **Path safety:** File operations sanitize usernames and verify resolved paths stay within `./data/`.
-- **Pagination:** Leaderboard queries bounded (limit: 1-100).
-- **Claim locking:** In-process promise chain prevents concurrent double-claims per user (single-instance only).
+- **Auth:** All authenticated endpoints validate Telegram `initData` signatures (24h expiry).
+- **Wallet binding:** TON Connect ton_proof — stateless HMAC nonce + Ed25519 signature
+  verification; each rebind needs a fresh, userId-bound nonce (no replay across accounts).
+- **Money rail:** signed xRocket webhook (timing-safe HMAC over the raw body), atomic
+  `$gte` debit CAS (overdraft impossible), idempotent ledger, reconciliation guard.
+- **NFT mint:** admin-only authz, server-side floor re-check, CAS mint-claim
+  (`mintingInProgress`) → single mint on double-approve.
+- **Input validation:** NFT image types whitelisted, colors bounded (0-10), indexes
+  non-negative; addresses wrapped in try-catch.
+- **Path safety:** file ops sanitize usernames and verify resolved paths stay within `./data/`.
+- **Pagination:** leaderboard queries bounded (limit 1-100, skip ≥ 0).
+- **Claim locking:** in-process promise chain prevents concurrent double-claims (single-instance only).
 
 ## Conventions
 
 - ESM-only imports (no CommonJS).
-- Type imports sorted before value imports (perfectionist/sort-imports).
+- Type imports sorted before value imports; value-external before value-internal (perfectionist/sort-imports).
 - Keep frontend and backend dependencies isolated (separate `package.json`).
-- Backend handlers use dependency injection pattern for testability.
+- Backend handlers use the dependency-injection pattern for testability; config-touching
+  modules split into a pure handler + a composer.
 - Avoid editing generated output under `build/`.

--- a/CODEX.md
+++ b/CODEX.md
@@ -15,21 +15,20 @@ Help contributors and automation tools work effectively in this repo by providin
 - Keep ESM import style (no CommonJS `require`).
 - Frontend (`src/frontend/`) is a separate package — keep deps isolated.
 - No semicolons, single quotes, 2-space indent (Prettier enforced).
-- Type imports must come before value imports (`perfectionist/sort-imports`).
+- Type imports come before value imports; value-external before value-internal (`#root/*`) (`perfectionist/sort-imports`).
 - Use `folderPath()` from `src/common/helpers/files.ts` for any user-data file paths — it sanitizes filenames.
-- Never hardcode secrets client-side. Captcha uses HMAC tokens, not shared keys.
+- Never hardcode secrets client-side. Wallet binding uses TON Connect ton_proof + HMAC nonces, not shared keys.
 - New routes/commands → use the DI handler pattern (see below).
 
 ## Key Entry Points
-- `src/main.ts` — Startup: MongoDB → bot → server → subscription → start
+- `src/main.ts` — Startup: MongoDB → bot → server → subscription → background workers
 - `src/server.ts` — Fastify server: handler registration with `/api/` prefixes
 - `src/bot/index.ts` — Bot middleware chain (order matters!) and feature registration
-- `src/config.ts` — Environment configuration (znv + zod, lazy proxy singleton)
-- `src/subscription.ts` — TON blockchain transaction poller (wiring)
-- `src/subscription-core.ts` — `AccountSubscription` polling class
-- `src/subscription-start.ts` — DI-friendly startup builder
-- `src/frontend/src/routes.ts` — Frontend route table (some entries have `showInMenu: false`)
-- `src/frontend/src/stores/userStore.ts` — Pinia store (wallet, user, balance, initData)
+- `src/config.ts` — Environment configuration (znv + zod, lazy proxy; **throws on read when `NODE_ENV=test`**)
+- `src/subscription-core.ts` — TON transaction watcher (`AccountSubscription`); donations → `votes` faucet
+- `src/subscription.ts` — Composer wiring for the watcher
+- `src/frontend/src/routes.ts` — Frontend route table; `router.beforeEach` locks non-minted users to `/mint`
+- `src/frontend/src/stores/userStore.ts` — Pinia store (wallet, user, balance, initData, minted/mintState)
 
 ## Handler / Command Pattern
 Backend handlers and bot commands use dependency injection for testability:
@@ -40,48 +39,54 @@ Dependencies interface → createDefaultDependencies() → buildHandler(deps) �
 
 Tests inject mocks via `buildHandler({ mockFn })`. See `auth-handler.test.ts` for reference.
 
-When the production deps would import `#root/config` (e.g. via `is-admin.ts` or `ton.ts`), split the module:
+When the production deps would import `#root/config` (e.g. via `is-admin.ts`, `ton.ts`, or `xrocket-client.ts`), split the module:
 - `foo-handler.ts` — pure logic, no config-touching imports.
 - `foo.ts` — Composer wiring that imports the heavy bits and passes them in.
 
-Examples: `transaction-handler.ts` + `admin/transaction.ts`, `user-handler.ts` + `admin/user.ts`.
+Examples: `mint-handler.ts` + `mint.ts`, `transaction-handler.ts` + `admin/transaction.ts`, `wallet-handler.ts` + `wallet.ts`.
 
 ## Data Models (src/common/models/)
-- **User** — Telegram user profile, wallet, votes (bigint), game state, minted status
-- **Balance** — Change ledger with BalanceChangeType enum (Initial, Deposit, Withdraw, Dice, Referral, Donation, Task, Claim, Trade — `Dice` and `Task` are legacy values still in the enum)
-- **Claim** — Daily streak tracking (60s cooldown, 10-day max, 100 base reward with multiplier)
-- **CNFT** — NFT metadata: type (Whale/Diamond/Coin/Knight/Common; the `Dice` variant remains in `CNFTImageType` but is no longer awarded), color (0-10), index
-- **Transaction** — TON transaction records (deduplication by lt + hash)
-- **Vote** — Referral relationship (giver → receiver)
+- **User** — Telegram profile, wallet, `votes` (bigint = DB-only $CUBE), `minted`/`mintState`, mint-claim CAS fields
+- **Balance** — CUBE ledger with `BalanceChangeType` (Claim, Referral, Donation, Spend, Expedition, CastleUpgrade, Recruit, ArenaEntry, RaidStake, …; `Dice`/`Task`/`Trade` are legacy values still in the enum)
+- **CNFT** — NFT metadata: type (Whale/Diamond/Coin/Knight/Common; `Dice` variant remains in `CNFTImageType` but is no longer awarded), color (0-10), index
+- **Castle / Hero / Equipment / Match** — Ancient-worlds game state (resources, heroes, gear, PvP)
+- **Expedition / World / Energy / Tournament / SeasonPass** — Expedition economy + monetization
+- **WalletBalance / WalletLedger / WalletGuard** — USDT money rail (bigint micro-USDT), separate from the CUBE ledger
+- **Transaction** — TON transaction records (dedup by lt + hash); **Vote** — referral relationship
 
 ## API Routes (under /api/)
-- `POST /api/auth/login` — Telegram initData auth (24h expiry) + referral assignment
-- `POST /api/auth/set-wallet` — Store TON wallet (validates via Address.parse)
-- `GET /api/captcha/check` — Verify DOOM captcha with HMAC-signed token
+- `POST /api/auth/login` — Telegram initData auth (24h) + upsert; returns `minted`/`mintState`
+- `POST /api/auth/wallet-nonce` + `POST /api/auth/set-wallet` — TON Connect ton_proof wallet binding
+- `POST /api/mint/{quote,generate,status}` — Webview semi-auto NFT mint (escalating floor, queue rank)
 - `GET /api/nft/*` — NFT metadata + image endpoints (whitelisted params)
-- `GET /api/users/balances` — Aggregate stats (public, no auth)
-- `GET /api/users/leaderboard` — Paginated ranking (limit capped at 100)
-- `POST /api/users/claim` — Daily reward claim (in-process lock per user)
-- `POST /api/users/claim/status` — Current claim status without claiming
+- `GET /api/users/{balances,leaderboard}` — Aggregate stats / paginated ranking (limit ≤ 100)
+- `POST /api/users/claim` + `/claim/status` — Daily reward claim (in-process lock per user)
+- `POST /api/game/*` — Castle, heroes, dungeon, quest, boss, arena/raid, expedition, tournament, energy, ads
+- `/api/wallet/*` — xRocket USDT rail (balance, invoice, buy-energy, withdraw, transfer, signed webhook)
 
-## Captcha Flow (vestigial)
-The DOOM-captcha endpoints and `generateCaptchaToken()` (HMAC over `BOT_TOKEN`) still live in `src/backend/captcha.ts` and are mounted at `/api/captcha`, but nothing currently calls them — the dice command that issued tokens was removed. `User.suspicionDices` remains on the model. If you reuse the flow: keep the HMAC secret server-side, do not expose `BOT_TOKEN` to the iframe.
+## Game Economy (high-signal)
+$CUBE is **DB-only** — `User.votes` + the `Balance` ledger are canonical; there is no on-chain
+$CUBE jetton (the old bridge and the CUBE→SATOSHI exchange were removed). Mint funding is **TON
+donations only** (watcher → `addPoints(..., Donation)`). NFT minting is admin-gated (binary
+Approve/Return) and the NFT gates game entry. **Invariant: sinks before faucets** — the
+expedition CUBE faucet stays behind `EXPEDITION_FAUCET_ENABLED` (default off). See `docs/ECONOMY.md`.
 
 ## Useful Commands
-- `npm run lint` — ESLint (@antfu/eslint-config)
+- `npm run lint` — ESLint
 - `npm run typecheck` — TypeScript (tsc)
 - `npm run format` — Prettier
-- `npm run test:backend` — 422 tests across 53 files (Node.js test runner, ~5s)
+- `npm run test:backend` — full backend suite (Node.js test runner)
 - `npm run test:coverage` — per-file line / branch / function coverage
 - `npm run build:all` — Build backend + frontend
 
 ## Before Finishing Any Change
 ```bash
-npm run lint && npm run typecheck && npm run test:backend && npm --prefix src/frontend run build
+npm run lint && npm run typecheck && npm run test:backend && npm run build:all
 ```
 
 ## Further Reading
-- `CLAUDE.md` — Compact project guide for AI agents
+- `CLAUDE.md` — Detailed, current project guide for AI agents
 - `ARCHITECTURE.md` — System architecture with diagrams
 - `AGENTS.md` — Agent-specific orientation
+- `docs/ECONOMY.md` — Tokenomics & sink discipline
 - `docs/FUTURE_DEVELOPMENT.md` — Prioritized improvements and feature ideas

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 🕋 Cube Worlds Bot 🎲
+# 🕋 Cube Worlds Bot
 
 [![Telegram](https://img.shields.io/badge/Telegram-@cube__worlds__bot-26A5E4?logo=telegram&logoColor=white)](https://t.me/cube_worlds_bot)
 [![CI](https://github.com/cube-worlds/cube_worlds/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/cube-worlds/cube_worlds/actions/workflows/main.yml)
 ![Coverage](docs/coverage.svg)
-![Tests](https://img.shields.io/badge/tests-422%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-749%20passing-brightgreen)
 ![Node](https://img.shields.io/badge/node-%E2%89%A518-339933?logo=node.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?logo=typescript&logoColor=white)
 ![TON](https://img.shields.io/badge/TON-blockchain-0098EA?logo=tonkeeper&logoColor=white)
@@ -11,17 +11,18 @@
 
 <a target="_blank" href="https://dorahacks.io/buidl/10796"><img src="https://cdn.dorahacks.io/images/buidl-embed/light-simple.png" height="33" width="84" alt="DoraHacks BUIDL"/></a>
 
-A Telegram Mini App game on the TON blockchain. Earn **$CUBE** through daily claims and referrals, then have admins mint a generative pixel-art NFT for top holders. Includes a CUBE → SATOSHI jetton swap and an idle-clicker mining mode.
+A Telegram Mini App game on the TON blockchain. Earn **$CUBE** (a DB-only soft currency) through daily claims, referrals, and TON donations; rank a queue to mint a generative pixel-art NFT that gates game entry; then play an ancient-world ARPG/4X loop — castles, heroes, expeditions, PvP arena & raids, and weekly tournaments — with an optional real-money (USDT) rail via xRocket.
 
 ---
 
 ## ✨ Highlights
 
 - 🎮 **Mini App game** — Vue 3 frontend served straight inside Telegram, with TonConnect wallet integration.
-- 🪙 **Daily claims + referrals** — daily streak bonuses with premium-user multipliers, referral chain rewards.
-- 🎨 **AI-generated NFTs** — Stability AI image-to-image + ChatGPT descriptions, pinned to IPFS, minted as TON cNFTs from an admin-curated queue.
-- ⛓️ **On-chain transaction monitoring** — Fastify worker polls TON for incoming payments and credits points automatically.
-- 🧪 **Heavily tested backend** — 422 tests on the Node.js built-in test runner.
+- 🪙 **DB-only $CUBE** — earned via daily streaks (premium multipliers), referrals, and TON donations; `User.votes` + the `Balance` ledger are canonical (no on-chain jetton).
+- 🎨 **NFT-gated entry** — Stability AI + ChatGPT generate a pixel-art cNFT through a player-facing webview mint with an escalating eligibility floor; a binary admin Approve/Return deploys it on-chain. Owning it unlocks the game.
+- 🏰 **Ancient-worlds economy** — castles & resource production, hero recruitment / dungeons / quests, weekly boss, async-snapshot PvP (arena + castle raids on an ELO ladder), and a congestion-based expedition loop.
+- 💰 **Monetization rails** — xRocket USDT wallet (deposits/withdrawals/transfers, reconciled), Telegram Stars Season Pass, Adsgram rewarded ads, and a weekly tournament with a rewards-pool payout.
+- 🧪 **Heavily tested backend** — 749 tests on the Node.js built-in test runner.
 
 ## 🏗️ Architecture
 
@@ -53,7 +54,8 @@ See **[ARCHITECTURE.md](ARCHITECTURE.md)** for the full system overview and runt
 | HTTP API   | [Fastify](https://fastify.dev/) + `@fastify/middie`, `@fastify/static`                 |
 | Frontend   | [Vue 3](https://vuejs.org/) + Vite + Pinia + [TonConnect](https://tonconnect.dev/)     |
 | Database   | MongoDB via [Typegoose](https://typegoose.github.io/typegoose/) (Mongoose decorators)  |
-| Blockchain | [@ton/ton](https://docs.ton.org/) for transactions, NFT minting, jetton operations      |
+| Blockchain | [@ton/ton](https://docs.ton.org/) for donations, wallet binding (ton_proof), NFT minting |
+| Money rail | [xRocket](https://pay.xrocket.tg/) USDT (micro-USDT ledger) + Telegram Stars (Season Pass) |
 | AI         | [Stability AI](https://stability.ai/) (images) + OpenAI (NFT descriptions)             |
 | Storage    | [Pinata](https://pinata.cloud/) IPFS for NFT metadata + artwork                        |
 | Quality    | [@antfu/eslint-config](https://github.com/antfu/eslint-config), Prettier, tsc, Husky   |
@@ -96,7 +98,7 @@ npm --prefix src/frontend run dev
 The backend uses Node.js's **built-in test runner** (`node --test`) — no Jest/Vitest. Handlers are written with **dependency injection** so tests can swap in mocks without spinning up Mongo, TON, or the bot. See [`src/backend/auth-handler.test.ts`](src/backend/auth-handler.test.ts) for the canonical pattern.
 
 ```bash
-npm run test:backend     # ~5s, 422 tests across 53 files
+npm run test:backend     # 749 tests across 113 files (Node test runner)
 npm run test:coverage    # full per-file coverage report
 ```
 
@@ -106,34 +108,31 @@ Areas at or near full coverage: every backend route handler, all callback-data p
 
 ```
 src/
-  main.ts               # entrypoint — MongoDB → bot → server → subscription → start
+  main.ts               # entrypoint — MongoDB → bot → server → subscription → workers
   server.ts             # Fastify, registers /api/* handlers
-  config.ts             # znv + Zod, lazy proxy singleton
-  subscription.ts       # TON transaction poller (composer wiring)
-  subscription-core.ts  # AccountSubscription polling class
-  subscription-start.ts # DI-friendly startup builder
+  config.ts             # znv + Zod, lazy proxy (throws on read when NODE_ENV=test)
+  subscription-core.ts  # TON transaction watcher (donations → votes)
+  subscription.ts       # composer wiring for the watcher
   bot/
     index.ts            # middleware chain (ORDER MATTERS) + feature registration
     context.ts          # Grammy Context + SessionData types
-    features/*.ts       # commands: start, help, line, stats, whales, unhandled,
-                        #           removed-commands, admin/{queue,collection,
-                        #           parameters,transaction,user}
+    features/*.ts       # commands: start, help, line, stats, whales, season-pass,
+                        #           unhandled, removed-commands, admin/{queue,
+                        #           collection,parameters,transaction,user}
     filters/is-admin.ts # auth filter for admin-only commands
-    handlers/           # error boundary + sync-commands runner
-    middlewares/*.ts    # attach-user, reaction, update-logger
-    keyboards/*.ts      # inline keyboards (photo, queue-menu)
-    callback-data/*.ts  # typed callback-data packers
-  backend/              # Fastify handlers (auth, claim, leaderboard, nft, balances, captcha)
+  backend/              # Fastify handlers (DI-split): auth, mint, claim, castle, hero,
+                        #   dungeon, quest, boss, pvp, expedition, tournament, wallet, …
+                        #   plus settlement + NFT-mint background runners
   common/
-    models/             # Typegoose: User, Balance, Claim, CNFT, Transaction, Vote
-    helpers/            # ton, ipfs, generation, files, telegram, random, satoshi, …
+    models/             # Typegoose: User, Balance, CNFT, Castle, Hero, Match, Wallet*, …
+    helpers/            # ton, ipfs, generation, files, mint-floor, combat, production, …
   frontend/             # Vue 3 + Vite (separate package.json)
-    captcha/            # standalone DOOM captcha (HTML/JS, not Vue; currently unused)
+    src/routes.ts       # route table; non-minted users are locked to /mint
 locales/                # Fluent (.ftl) translations
-docs/                   # research snapshots, coverage badge, future development
+docs/                   # design & research docs, coverage badge, economy model
 ```
 
-> The dice game (`/dice`), NFT-mint command (`/mint`), and story game (`/play`) were removed; `removed-commands.ts` catches those slash commands and points users to the Mini App. The HMAC captcha endpoint and `User.suspicionDices` field remain as orphaned scaffolding from the dice flow.
+> The dice game (`/dice`), NFT-mint command (`/mint`), and story game (`/play`) were removed; `removed-commands.ts` catches those slash commands and points users to the Mini App. The on-chain $CUBE jetton bridge and the CUBE→SATOSHI exchange were also removed in the DB-only pivot — see [CLAUDE.md](CLAUDE.md).
 
 ## 📚 Further Reading
 

--- a/docs/ANCIENT_WORLDS_PLAN.md
+++ b/docs/ANCIENT_WORLDS_PLAN.md
@@ -12,6 +12,18 @@
 
 ---
 
+> ## ⚠️ Status update (2026-06-14) — read first
+>
+> This plan is the **design vision**; parts of it have shipped and one major decision was reversed. Current ground truth lives in [`../CLAUDE.md`](../CLAUDE.md).
+>
+> **Shipped:** Phase A (castles, resources, 8h production), Phase B (heroes, recruitment, daily dungeon, combat resolver) + Plan 6 (equipment, 8h quest, boss week), and Phase C slice 1 (async-snapshot PvP — arena + castle raids on an ELO ladder). Plus the expedition economy, weekly tournament, Season Pass, rewarded ads, and the xRocket USDT money rail.
+>
+> **Decision reversed — $CUBE is now DB-only.** This doc and the research trilogy assume $CUBE eventually becomes an on-chain jetton. **That was undone.** $CUBE stays a DB-only soft currency (`User.votes` + the `Balance` ledger are canonical); the on-chain $CUBE bridge and the CUBE→SATOSHI exchange were removed. The only on-chain mint is the **entry-gating NFT** (webview semi-auto mint + escalating floor + binary admin Approve/Return). Where this doc says "promote CUBE to a jetton" or "multi-jetton resources," read it as DB-only ledgers.
+>
+> **Still pending (ops):** deploy + audit the NFT collections (`*_COLLECTION_ADDRESS` gates), then flip `EXPEDITION_FAUCET_ENABLED` once the CUBE sinks are tuned. Deferred features: clans, equipment trading post, Tact PvP escrow.
+
+---
+
 ## 0. Where this fits
 
 ### What the codebase already gives us (May 2026)

--- a/docs/FUTURE_DEVELOPMENT.md
+++ b/docs/FUTURE_DEVELOPMENT.md
@@ -1,5 +1,13 @@
 # Future Development Ideas
 
+> **Status note (2026-06-14).** Written before the DB-only $CUBE pivot and the
+> ancient-worlds build-out. Several "New Features" below have since shipped in some form
+> (achievements/CNFT tiers, seasonal events via the weekly tournament & boss week, push
+> via Season Pass flows) or were reframed (the marketplace is now a deferred Phase C
+> trading post). Items referencing SATOSHI/mining are obsolete — those rails were
+> removed. Treat this as a candidate list, not current state; ground truth is
+> [`../CLAUDE.md`](../CLAUDE.md).
+
 ## Recently Completed
 
 The following items have been addressed:
@@ -42,7 +50,7 @@ The NFT handler is the only backend handler without test coverage. Add:
 
 ### 3. Re-enable NFT Mint Notifications
 **Priority:** High | **Effort:** Small
-`sendNewPlaces` is commented out in `src/bot/features/admin/queue.ts:245` (with the import also commented at line 35). Review the notification logic and re-enable it so users get notified when their NFT is minted.
+The admin `/queue` flow was rewritten to a binary Approve/Return action (`queue-approval-handler.ts`). Wire a user-facing notification on successful mint/approval so users learn their NFT was minted (and on Return, that changes were requested).
 
 ### 4. Leaderboard Caching
 **Priority:** Medium | **Effort:** Small
@@ -90,8 +98,8 @@ Use Telegram's messaging capabilities to send proactive notifications:
 
 ### 11. In-App Trading / Marketplace
 **Priority:** Low | **Effort:** Large
-The exchange feature currently only supports CUBE-to-SATOSHI swaps via `SatoshiExchange.vue`. Consider building:
-- Peer-to-peer NFT trading between users
+(The CUBE→SATOSHI swap that originally motivated this item was removed in the DB-only pivot.) Deferred to Phase C as the equipment **trading post** (5% burn). Consider building:
+- Peer-to-peer NFT / equipment trading between users
 - Auction system for rare NFTs
 - Price history charts
 
@@ -139,7 +147,7 @@ The current NFT image generation (`src/common/helpers/generation.ts`) uses Stabi
 ## Technical Debt
 
 ### 17. Add E2E Tests
-Backend has 422 unit/integration tests across 53 files; everything else is gap. Add:
+Backend has 749 unit/integration tests across 113 files; the frontend and E2E flows are the gap. Add:
 - Frontend component tests (Vitest + Vue Test Utils)
 - E2E tests for critical flows (login → claim → check balance)
 - Bot command integration tests

--- a/docs/MARKET_RESEARCH.md
+++ b/docs/MARKET_RESEARCH.md
@@ -4,6 +4,8 @@ _Compiled 2026-05-18. Two parallel research passes on the 2024–2026 Telegram c
 
 Companion docs: [NFT_INTERACTIONS.md](NFT_INTERACTIONS.md) (cross-chain NFT mechanics catalog), [TOKEN_INTERACTIONS.md](TOKEN_INTERACTIONS.md) (token sources/sinks/utility and Cube Worlds economy plan).
 
+> **⚠️ Pre-pivot research (2026-06-14 note).** This is a point-in-time research snapshot. Since it was compiled, Cube Worlds went **DB-only $CUBE** (no on-chain jetton), made the entry NFT a hard game gate, and shipped the ancient-worlds loop (castles/heroes/PvP/expeditions) + monetization rails. The strategic analysis below still holds; treat any reference to an on-chain $CUBE jetton or the CUBE→SATOSHI swap as superseded. Ground truth: [`../CLAUDE.md`](../CLAUDE.md); current plan status in [ANCIENT_WORLDS_PLAN.md](ANCIENT_WORLDS_PLAN.md).
+
 ---
 
 ## TL;DR

--- a/docs/NFT_INTERACTIONS.md
+++ b/docs/NFT_INTERACTIONS.md
@@ -4,6 +4,8 @@ _Compiled 2026-05-19. Cross-chain research on NFT interaction mechanics in Web3 
 
 Companion docs: [MARKET_RESEARCH.md](MARKET_RESEARCH.md) (Telegram crypto-game landscape), [TOKEN_INTERACTIONS.md](TOKEN_INTERACTIONS.md) (token economy patterns and Cube Worlds sink plan).
 
+> **⚠️ Pre-pivot research (2026-06-14 note).** Point-in-time NFT-mechanics catalog. Since it was compiled, Cube Worlds shipped NFT collections for the entry pass plus castle / hero / equipment items (all DB-canonical with deploy-gated on-chain mint, gated behind `*_COLLECTION_ADDRESS`), and made $CUBE **DB-only** (no on-chain jetton). The pattern catalog still applies; map any "jetton" reference to a DB ledger. Ground truth: [`../CLAUDE.md`](../CLAUDE.md).
+
 ---
 
 ## TL;DR

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,14 @@
 
 Research, design, and planning docs for the Cube Worlds Telegram Mini App.
 
-For system architecture and code structure, see [../ARCHITECTURE.md](../ARCHITECTURE.md) at the repo root.
+For system architecture and code structure, see [../ARCHITECTURE.md](../ARCHITECTURE.md) at the repo root. For **current** project state (feature-by-feature), see [../CLAUDE.md](../CLAUDE.md).
+
+> **Note (2026-06-14):** most docs here are point-in-time research/design (May 2026), pre-dating the **DB-only $CUBE** pivot. Each carries a status banner. Key reversal: $CUBE is permanently DB-only (no on-chain jetton), and the CUBE→SATOSHI exchange was removed. `ECONOMY.md` is kept current.
 
 ## Primary plan
 
 ### [ANCIENT_WORLDS_PLAN.md](ANCIENT_WORLDS_PLAN.md) — Game design, contracts, roadmap
-Synthesis layer on top of the research trilogy. Lays out an ancient-world ARPG/4X (inspired by Diablo II / Lineage II / HOMM3) reshaped as a casual TMA with castles, PvP/PvE, an 8-hour activity window, multi-jetton resource economy, and existing CNFT as game pass. Covers game loop, TON contract list, Phase A–F roadmap mapped to existing files, and risks.
+Synthesis layer on top of the research trilogy. Lays out an ancient-world ARPG/4X (inspired by Diablo II / Lineage II / HOMM3) reshaped as a casual TMA with castles, PvP/PvE, an 8-hour activity window, a (now DB-only) resource economy, and the entry NFT as game pass. Covers game loop, TON contract list, Phase A–F roadmap mapped to existing files, and risks. Phases A–C slice 1 have shipped — see the status banner atop the doc.
 - **Start here** if you want the playable shape and build order.
 
 ### [ECONOMY.md](ECONOMY.md) — Financial model & tokenomics
@@ -30,9 +32,9 @@ A catalog of 20 NFT interaction patterns (breeding, fusion, evolution, rentals, 
 - **Cube Worlds catalog** in Part 4: CNFT-as-multiplier → achievement SBTs → burn-to-upgrade fusion → CNFT rental → season access pass.
 
 ### 3. [TOKEN_INTERACTIONS.md](TOKEN_INTERACTIONS.md) — Fungible-token mechanics across all chains
-Sources, sinks, utility patterns, and economy models (single-token vs dual-token vs off-chain-points-then-TGE) with the survivor games' lessons. Anchored on the structural problem: Cube Worlds has 4 token sources and exactly 1 sink.
-- **Start here if** you're tuning the CUBE/SATOSHI economy.
-- **Cube Worlds plan** in Part 4: add 3 sinks first (dice refill, season pass, tournaments), then promote CUBE to on-chain jetton, then add Stars rail.
+Sources, sinks, utility patterns, and economy models (single-token vs dual-token vs off-chain-points-then-TGE) with the survivor games' lessons. Anchored on the (then) structural problem: Cube Worlds had 4 token sources and exactly 1 sink.
+- **Start here if** you're tuning the CUBE economy.
+- **Partly superseded:** its "add 3 sinks first" recommendation shipped; its "then promote CUBE to on-chain jetton" recommendation was **reversed** — $CUBE stays DB-only. See the doc's banner.
 
 ## Engineering backlog
 

--- a/docs/TOKEN_INTERACTIONS.md
+++ b/docs/TOKEN_INTERACTIONS.md
@@ -4,9 +4,13 @@ A survey of how fungible tokens (ERC-20 and equivalents — SPL, Jetton on TON, 
 
 Companion docs: [MARKET_RESEARCH.md](MARKET_RESEARCH.md) (Telegram + Web3 landscape), [NFT_INTERACTIONS.md](NFT_INTERACTIONS.md) (NFT mechanics).
 
+> **⚠️ Superseded in parts (2026-06-14 note).** This doc's headline recommendation — "add sinks, then **promote CUBE to an on-chain jetton**" — was **reversed**. $CUBE is now permanently **DB-only** (`User.votes` + the `Balance` ledger; no jetton master, no bridge). The CUBE→SATOSHI exchange described in Part 0 was **removed** along with the SATOSHI rail. The "add 3 sinks first" half of the plan **did** ship: refill, weight-boost, and tournament-entry are live CUBE sinks, satisfying the sinks-before-faucet invariant that still gates the expedition faucet (`EXPEDITION_FAUCET_ENABLED`, default off). The cross-chain token-mechanics survey below remains useful; treat the Cube-Worlds-specific "current surface" and the jetton-promotion plan as historical. Ground truth: [`../CLAUDE.md`](../CLAUDE.md) and [ECONOMY.md](ECONOMY.md).
+
 ---
 
 ## Part 0 — Cube Worlds' Current Token Surface
+
+> _Historical (May 2026 snapshot — describes the pre-pivot state with SATOSHI and a single sink). See the banner above for what changed._
 
 Confirmed from code (citations in section 4):
 


### PR DESCRIPTION
## Summary

Documentation-only refresh to bring the repo's agent instructions and design docs in line with the merged **DB-only \$CUBE + NFT-gated mint** state (#267) and the ancient-worlds build-out. No code changes.

The supergoal scratch dir was also removed and the codebase was verified clean (no dead code — the "orphaned scaffolding" the old docs warned about was already gone).

## Operational reference — full rewrites
- **AGENTS.md / CODEX.md / ARCHITECTURE.md / README.md** — accurate source layout, models, routes, economy invariants (DB-only \$CUBE, sinks-before-faucets), xRocket money rail, settlement + NFT-mint workers, ton_proof wallet binding. Dropped stale SATOSHI / captcha / dice references; test badge 422 → 749.

## Research/design archives — banner + targeted corrections
Bodies preserved as dated May-2026 snapshots; each gets a status banner and the few reversed decisions are corrected:
- **ANCIENT_WORLDS_PLAN.md** — shipped/reversed/pending banner.
- **TOKEN_INTERACTIONS.md** — flags the reversed "promote CUBE to on-chain jetton" plan.
- **MARKET_RESEARCH.md / NFT_INTERACTIONS.md** — pre-pivot banners.
- **FUTURE_DEVELOPMENT.md** — fixed the SATOSHI-swap item, the rewritten queue item, and the test count.
- **docs/README.md** — index banner + corrected trilogy descriptions.

## Verification
`lint`, `typecheck`, `test:backend` (749 pass), and `build:all` all green. Markdown is intentionally not prettier-formatted in this repo (lint-staged is `*.ts`-only), so edits match the existing hand-written style.